### PR TITLE
Command user experience updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,32 @@
           "when": "true",
           "command": "pros.upload&build"
         }
+      ],
+      "commandPalette": [
+        {
+          "when": "pros.isPROSProject",
+          "command": "pros.upload&build"
+        },
+        {
+          "when": "pros.isPROSProject",
+          "command": "pros.upload"
+        },
+        {
+          "when": "pros.isPROSProject",
+          "command": "pros.build"
+        },
+        {
+          "when": "pros.isPROSProject",
+          "command": "pros.clean"
+        },
+        {
+          "when": "pros.isPROSProject",
+          "command": "pros.terminal"
+        },
+        {
+          "when": "pros.isPROSProject",
+          "command": "pros.upgrade"
+        }
       ]
     },
     "customEditors": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "Other"
   ],
   "activationEvents": [
-    "workspaceContains:**/project.pros"
+    "workspaceContains:**/project.pros",
+    "onCommand:pros.new",
+    "onCommand:pros.helloWorld",
+    "onCommand:pros.welcome"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,10 @@ let analytics: Analytics;
 export function activate(context: vscode.ExtensionContext) {
   analytics = new Analytics(context);
 
+  workspaceContainsProjectPros().then((value) => {
+      vscode.commands.executeCommand("setContext", "pros.isPROSProject", value);
+  });
+
   const terminal = vscode.window.createTerminal("PROS Terminal");
   terminal.sendText("pros build-compile-commands");
 
@@ -74,4 +78,26 @@ export function activate(context: vscode.ExtensionContext) {
 
 export function deactivate() {
   analytics.endSession();
+}
+
+async function workspaceContainsProjectPros(): Promise<boolean> {
+  const filename = "project.pros";
+
+  if (vscode.workspace.workspaceFolders === undefined || vscode.workspace.workspaceFolders === null) {
+    return false;
+  }
+
+  let exists = true;
+  try {
+    // By using VSCode's stat function (and the uri parsing functions), this code should work regardless
+    // of if the workspace is using a physical file system or not.
+    const workspaceUri = vscode.workspace.workspaceFolders[0].uri;
+    const uriString = `${workspaceUri.scheme}:${workspaceUri.path}/${filename}`;
+    const uri = vscode.Uri.parse(uriString);
+    await vscode.workspace.fs.stat(uri);
+  } catch (e) {
+    console.error(e);
+    exists = false;
+  }
+  return exists;
 }


### PR DESCRIPTION
### What

This PR adds appropriate commands to the `activationEvents` array in `package.json` and hides commands which can only be run inside a PROS project from the command palette when a `project.pros` can't be located in the workspace root.

### Why

Adding commands like `pros.new` as an activation event allows users to call them without getting a command not defined error. This means that new projects can be created without opening an existing one.

Hiding commands which can't do anything without a proper project open prevents users from misusing the extension unintentionally.

### Extra Notes

The code for detecting `project.pros` does not recursively look for the file like the activation event does and it does not iterate through every workspace. However, in 95% of cases it should work just fine. It is also located in `extension.ts` which may not be an appropriate place for this kind of utility function.