### PR TITLE
🚸 Generate a CDB entry for files when they are created in a project

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "pros",
-  "version": "0.0.1",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pros",
-      "version": "0.0.1",
+      "version": "0.1.1",
+      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@purduesigbots/pros-cli-middleware": "^2.5.2",
         "@types/semver": "^7.3.6",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import {
 } from "./commands";
 import { ProsProjectEditorProvider } from "./views/editor";
 import { Analytics } from "./ga";
+import { TextDecoder, TextEncoder } from "util";
 
 let analytics: Analytics;
 
@@ -151,6 +152,83 @@ export function activate(context: vscode.ExtensionContext) {
     "prosTreeview",
     new TreeDataProvider()
   );
+
+  // heuristic to add new files to the compilation database without requiring a full build
+  vscode.workspace.onDidCreateFiles(async (event) => {
+    // terminate early if there's no pros project or workspace folder open
+    if (!await workspaceContainsProjectPros() || !vscode.workspace.workspaceFolders) {
+      return;
+    }
+    
+    const workspaceRootUri = vscode.workspace.workspaceFolders[0].uri;
+    const compilationDbUri = vscode.Uri.joinPath(workspaceRootUri, 'compile_commands.json');
+    
+    // first check if the cdb exists. if not, attempt to build the project to generate it
+    try {
+      await vscode.workspace.fs.stat(compilationDbUri);
+    } catch {
+      await vscode.commands.executeCommand("pros.clean");
+      await vscode.commands.executeCommand("pros.build");
+
+      // after building, check for cdb again. if still not present then just abandon the heuristic
+      try {
+        await vscode.workspace.fs.stat(compilationDbUri);
+      } catch {
+        return;
+      }
+    }
+
+    // now we know there is a cdb present, we can load it
+    const compilationDbData: [{arguments: string[], directory: string, file: string}] = JSON.parse(
+      new TextDecoder().decode(
+        await vscode.workspace.fs.readFile(compilationDbUri)
+      )
+    );
+
+    let compilationDbDirty = false;
+
+    const mainArgs = compilationDbData.find((entry) => entry.file === "src/main.cpp")?.arguments;
+
+    // if for some reason there isn't an entry for main.cpp then i give up
+    if (!mainArgs) {
+      return;
+    }
+
+    for (let file of event.files) {
+      // the cdb only has entries for source files
+      if (file.fsPath.includes("src")) {
+        // since the cdb encodes the file as a relative path we have to do the same for the files given to us by the event
+        const thisFileRelative = path.relative(workspaceRootUri.path, file.path);
+
+        // anyway, if there is already an entry for this file somehow, just skip it
+        if (compilationDbData.find((entry) => entry.file === thisFileRelative)) {
+          continue;
+        }
+
+        // pop object file and source file from the compiler arguments list from the copy we saved of the args for main.cpp
+        const [_objFile, _srcFile, ...args] = mainArgs.reverse();
+
+        // create an entry for this file
+        compilationDbData.push({
+          arguments: [
+            ...args.reverse(),                             // (re-reverse the arguments list)
+            `${thisFileRelative.replace('src', 'bin')}.o`, // sure hope there aren't users who have src/**/src/**/ in their projects...
+            thisFileRelative
+          ],
+          directory: workspaceRootUri.path,
+          file: thisFileRelative
+        });
+
+        // mark the cdb dirty
+        compilationDbDirty = true;
+      }
+    }
+
+    // write changes back to the cdb if there are any
+    if (compilationDbDirty) {
+      await vscode.workspace.fs.writeFile(compilationDbUri, new TextEncoder().encode(JSON.stringify(compilationDbData, undefined, 4)));
+    }
+  });
 
   context.subscriptions.push(ProsProjectEditorProvider.register(context));
 }


### PR DESCRIPTION
#### Summary:
<!-- Provide a concise description of your changes -->
Add an entry to compile_commands.json for new files created in a project

#### Motivation:
<!-- Provide a brief description of why you think these changes need to be made -->
Sometimes intellisense/code completion/etc can have issues when a new file is created because there's not yet an entry for it in the compilation database.
This change makes it so that users don't need to wait until their new files are minimally compilable before their code completion works.

##### References (optional):
<!-- If this PR is related to an issue or task, reference it here (e.g. closes #1) -->
N/A

#### Test Plan:
<!-- Provide a list of steps that can be taken to verify these changes work as intended -->

- [x] entry is created in compile_conmmands.json when a file is created in a pros project﻿
- [x] project is built and cdb is generated when it doesn't already exist on file creation
  - [x] an entry is added in this case too
