### PR TITLE
✨Button to Update Only CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
       {
         "command": "pros.uninstall",
         "title": "PROS: Uninstall PROS"
+      },
+      {
+        "command": "pros.updatecli",
+        "title": "PROS: Update PROS CLI"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,11 +18,13 @@ import {
 } from "./commands";
 import { ProsProjectEditorProvider } from "./views/editor";
 import { Analytics } from "./ga";
-import { install, paths, uninstall } from "./one-click/install";
+import { install, paths, uninstall, updateCLI } from "./one-click/install";
 import { TextDecoder, TextEncoder } from "util";
 let analytics: Analytics;
 
 export var terminal : vscode.Terminal;
+export var system : string;
+export const output = vscode.window.createOutputChannel("PROS Output");
 
 export function makeTerminal() {
   
@@ -43,13 +45,12 @@ export function makeTerminal() {
 }
 
 
-export const output = vscode.window.createOutputChannel("PROS Output");
 export function activate(context: vscode.ExtensionContext) {
   analytics = new Analytics(context);
   const globalPath = context.globalStorageUri.fsPath;
   
   // Figure out operating system
-  var system = "linux";
+  system = "linux";
   if (process.platform === "win32") {
     system = "windows";
   } else if (process.platform === "darwin") {
@@ -93,6 +94,10 @@ export function activate(context: vscode.ExtensionContext) {
     await upload();
   });
 
+  vscode.commands.registerCommand("pros.updatecli", async() => {
+    analytics.sendAction("updatecli");
+    await updateCLI(context);
+  });
   vscode.commands.registerCommand("pros.build", async () => {
     analytics.sendAction("build");
     await build();

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -7,7 +7,6 @@ var tar = require('tar-fs');
 import * as fs from 'fs';
 import { promisify } from "util";
 import * as stream from 'stream';
-import * as child_process from "child_process";
 import { paths } from './install';
 import * as path from 'path';
 export function download(context: vscode.ExtensionContext, downloadURL: string, storagePath: string, system: string) {

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -3,14 +3,19 @@ import * as path from 'path';
 import * as os from 'os';
 import { download } from './download';
 import { getCurrentVersion, getCliVersion, getInstallPromptTitle } from "./installed";
-import { makeTerminal } from '../extension'
+import { makeTerminal, system } from '../extension'
 import * as fs from 'fs';
+import { promisify } from "util";
+import internal = require("stream");
+import { downloadDirToExecutablePath } from "vscode-test/out/util";
+import { ProsProjectEditorProvider } from "../views/editor";
 var fetch = require('node-fetch');
 
 //TOOLCHAIN and CLI_EXEC_PATH are exported and used for running commands.
 export var TOOLCHAIN: string;
 export var CLI_EXEC_PATH: string;
 export var PATH_SEP: string;
+
 /*
 
 Code that maybe works to wait for both toolchain and cli to be installed???
@@ -64,25 +69,16 @@ export async function uninstall(context: vscode.ExtensionContext) {
     }
 }
 
-export async function install(context: vscode.ExtensionContext) {
-    const globalPath = context.globalStorageUri.fsPath;
-    var version = await getCliVersion('https://api.github.com/repos/purduesigbots/pros-cli/releases/latest');
-    console.log("Current CLI Version: " + version);
-
-    // Get system type, path string separator, CLI download url, and toolchain download url.
-    // Default variables are based on linux.
+async function getUrls(version : number) {
     var downloadCli = `https://github.com/purduesigbots/pros-cli/releases/download/${version}/pros_cli-${version}-lin-64bit.zip`;
     var downloadToolchain = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2";
-    var system = "linux";
 
-    if (process.platform === "win32") {
+    if (system === "windows") {
         // Set system, path seperator, and downloads to windows version 
-        system = "windows";
         downloadCli = `https://github.com/purduesigbots/pros-cli/releases/download/${version}/pros_cli-${version}-win-64bit.zip`;
         downloadToolchain = "https://artprodcus3.artifacts.visualstudio.com/A268c8aad-3bb0-47d2-9a57-cf06a843d2e8/3a3f509b-ad80-4d2a-8bba-174ad5fd1dde/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL3B1cmR1ZS1hY20tc2lnYm90cy9wcm9qZWN0SWQvM2EzZjUwOWItYWQ4MC00ZDJhLThiYmEtMTc0YWQ1ZmQxZGRlL2J1aWxkSWQvMjg4Ni9hcnRpZmFjdE5hbWUvdG9vbGNoYWluLTY0Yml00/content?format=file&subPath=%2Fpros-toolchain-w64-3.0.1-standalone.zip";
-    } else if (process.platform === "darwin") {
+    } else if (system === "macos") {
         // Set system, path seperator, and downloads to windows version 
-        system = "macos";
         downloadCli = `https://github.com/purduesigbots/pros-cli/releases/download/${version}/pros_cli-${version}-macos-64bit.zip`;
         downloadToolchain = "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-mac.tar.bz2";
         os.cpus().some(cpu => {
@@ -91,6 +87,18 @@ export async function install(context: vscode.ExtensionContext) {
             }
         });
     }
+
+    return [downloadCli, downloadToolchain];
+}
+
+export async function install(context: vscode.ExtensionContext) {
+    const globalPath = context.globalStorageUri.fsPath;
+    var version = await getCliVersion('https://api.github.com/repos/purduesigbots/pros-cli/releases/latest');
+    console.log("Current CLI Version: " + version);
+
+    // Get system type, path string separator, CLI download url, and toolchain download url.
+    // Default variables are based on linux.
+    let [downloadCli, downloadToolchain] = await getUrls(version);
     // Set the installed file names
     var cliName = `pros-cli-${system}.zip`;
     // Title of prompt depending on user's installed CLI
@@ -158,6 +166,31 @@ export async function install(context: vscode.ExtensionContext) {
     paths(globalPath, system, context);
 }
 
+export async function updateCLI(context: vscode.ExtensionContext) {
+    const globalPath = context.globalStorageUri.fsPath;
+    var title = await getInstallPromptTitle(path.join(globalPath, "install", `pros-cli-${system}`, "pros"));
+    if(title.includes("up to date")) {
+        vscode.window.showInformationMessage(title);
+        return;
+    }
+    const labelResponse = await vscode.window.showInformationMessage(title, "Update Now!", "No Thanks.");
+    if(labelResponse?.toLowerCase().includes("no thanks")) {
+        return;
+    }            
+    try {
+        await removeDirAsync(path.join(globalPath,"install",`pros-cli-${system}`),true);
+    } catch(err) {
+        //console.log(err);
+    }
+    var version = await getCliVersion('https://api.github.com/repos/purduesigbots/pros-cli/releases/latest');
+    let [downloadCli, downloadToolchain] = await getUrls(version);
+    // Set the installed file names
+    var cliName = `pros-cli-${system}.zip`;
+    // Title of prompt depending on user's installed CLI
+    download(context, downloadCli, cliName, system);
+    //await paths(globalPath, system ,context);
+    
+}
 
 export async function paths(globalPath: string, system: string, context : vscode.ExtensionContext) {
     // (path.join(globalPath, "install", `pros-cli-${system}`));

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -150,7 +150,6 @@ export async function install(context: vscode.ExtensionContext) {
                 .getConfiguration("pros")
                 .update("showInstallOnStartup", false);
         } else {
-            vscode.window.showInformationMessage("Install it later!");
             vscode.workspace
                 .getConfiguration("pros")
                 .update("showInstallOnStartup", false);
@@ -175,6 +174,7 @@ export async function updateCLI(context: vscode.ExtensionContext) {
     }
     if(title.includes("not")) {
         install(context);
+        return;
     }
     const labelResponse = await vscode.window.showInformationMessage(title, "Update Now!", "No Thanks.");
     if(labelResponse?.toLowerCase().includes("no thanks")) {

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -173,6 +173,9 @@ export async function updateCLI(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage(title);
         return;
     }
+    if(title.includes("not")) {
+        install(context);
+    }
     const labelResponse = await vscode.window.showInformationMessage(title, "Update Now!", "No Thanks.");
     if(labelResponse?.toLowerCase().includes("no thanks")) {
         return;

--- a/src/views/tree-view.ts
+++ b/src/views/tree-view.ts
@@ -8,7 +8,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
 	constructor() {
 		this.data = [new TreeItem('Quick Actions', [new TreeItem('Build & Upload', undefined, 'pros.build&upload'), new TreeItem('Upload', undefined, 'pros.upload'), new TreeItem('Build', undefined, 'pros.build'), new TreeItem('Clean', undefined, 'pros.clean'),new TreeItem('Brain Terminal', undefined, 'pros.terminal'),new TreeItem('Integrated Terminal', undefined, 'pros.showterminal')]),
 		new TreeItem('Conductor', [new TreeItem('Upgrade Project', undefined, 'pros.upgrade'), new TreeItem('Create Project', undefined, 'pros.new')]),
-		new TreeItem('Other',[new TreeItem('Install PROS', undefined, 'pros.install'),new TreeItem('Uninstall PROS', undefined, 'pros.uninstall')])];
+		new TreeItem('Other',[new TreeItem('Install PROS', undefined, 'pros.install'),new TreeItem('Uninstall PROS', undefined, 'pros.uninstall'),new TreeItem('Update PROS CLI', undefined, 'pros.updatecli')])];
 	}
 
 	getTreeItem(element: TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {


### PR DESCRIPTION
**Summary:**
Adds a new sidebar button and command to check if there is a CLI update and update only the CLI, not the toolchain.

**Motivation:**
Currently, the only way to update the CLI is by uninstalling and reinstalling PROS, which includes the ~200MB toolchain. These changes allow the user to update only the CLI, resulting in a much faster update.

**Test Case:**
Installed an outdated CLI version (3.2.2) into the one-click path and tested new command. The outdated CLI was deleted and the newest version was downloaded. The toolchain remained the same. This process was significantly faster than waiting for both the CLI and toolchain to download.