### PR TITLE
Generate compile-commands on launch + race cond fixes + update text fix

### DIFF
--- a/src/commands/create-project.ts
+++ b/src/commands/create-project.ts
@@ -136,7 +136,7 @@ const runCreateProject = async (
       try {
         // Command to run to make a new project with
         // user specified name, version, and location
-        var command = `pros c n "${projectPath}" ${target} ${version} --machine-output ${process.env["VSCODE FLAGS"]}`;
+        var command = `pros c n "${projectPath}" ${target} ${version} --machine-output --build-cache ${process.env["VSCODE FLAGS"]}`;
         console.log(command);
         const { stdout, stderr } = await promisify(child_process.exec)(
           command, { encoding: "utf8", maxBuffer: 1024 * 1024 * 50, timeout: 30000 }
@@ -147,7 +147,7 @@ const runCreateProject = async (
         }
 
         vscode.window.showInformationMessage("Project created!");
-      } catch (error) {
+      } catch (error: any) {
         console.log(error.stdout);
         throw new Error(parseErrorMessage(error.stdout));
       }
@@ -180,7 +180,7 @@ export const createNewProject = async () => {
       "vscode.openFolder",
       vscode.Uri.file(projectPath)
     );
-  } catch (err) {
+  } catch (err: any) {
     await vscode.window.showErrorMessage(err.message);
   }
 };

--- a/src/commands/create-project.ts
+++ b/src/commands/create-project.ts
@@ -74,7 +74,7 @@ const selectProjectName = async () => {
  */
 const selectKernelVersion = async (target: string) => {
   // Command to run to fetch all kernel versions
-  var command = `pros c ls-templates --target ${target} --machine-output ${process.env["VSCODE FLAGS"]}`
+  var command = `pros c ls-templates --target ${target} --machine-output ${process.env["VSCODE FLAGS"]}`;
   console.log(command);
   const { stdout, stderr } = await promisify(child_process.exec)(
     command/*, {timeout : 15000}*/
@@ -136,7 +136,7 @@ const runCreateProject = async (
       try {
         // Command to run to make a new project with
         // user specified name, version, and location
-        var command = `pros c n "${projectPath}" ${target} ${version} --machine-output ${process.env["VSCODE FLAGS"]}`
+        var command = `pros c n "${projectPath}" ${target} ${version} --machine-output ${process.env["VSCODE FLAGS"]}`;
         console.log(command);
         const { stdout, stderr } = await promisify(child_process.exec)(
           command, { encoding: "utf8", maxBuffer: 1024 * 1024 * 50, timeout: 30000 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,54 +18,45 @@ import {
 } from "./commands";
 import { ProsProjectEditorProvider } from "./views/editor";
 import { Analytics } from "./ga";
-import { install, paths, uninstall, updateCLI } from "./one-click/install";
+import { install, configurePaths, uninstall, updateCLI } from "./one-click/install";
 import { TextDecoder, TextEncoder } from "util";
 let analytics: Analytics;
 
-export var terminal : vscode.Terminal;
 export var system : string;
 export const output = vscode.window.createOutputChannel("PROS Output");
 
-export function makeTerminal() {
-  
-  var tc = null;
-  for(let term of vscode.window.terminals) {
-    if(term.name==="PROS Terminal") {
-      if(tc) {
-        term.dispose();
-      }
-      tc = term;
-    }
+/// Get a reference to the "PROS Terminal" VSCode terminal used for running 
+/// commands.
+export const getProsTerminal = async (context: vscode.ExtensionContext): Promise<vscode.Terminal> => {
+  const prosTerminals = vscode.window.terminals.filter(t => t.name === "PROS Terminal");
+  if (prosTerminals.length > 1) {
+    // Clean up duplicate terminals
+    prosTerminals.slice(1).forEach(t => t.dispose());
   }
-  if(!tc) {
-    terminal =  vscode.window.createTerminal({name:"PROS Terminal", env: process.env});
-  } else {
-    terminal = tc;
-  }
-}
 
+  // Create a new PROS Terminal if one doesn't exist
+  if (prosTerminals.length) {
+    return prosTerminals[0];
+  }
+
+  if (!process.env["PATH"]?.includes("pros-cli")) {
+    await configurePaths(context);
+  }
+
+  return vscode.window.createTerminal({name:"PROS Terminal", env: process.env});
+};
 
 export function activate(context: vscode.ExtensionContext) {
   analytics = new Analytics(context);
-  const globalPath = context.globalStorageUri.fsPath;
   
-  // Figure out operating system
-  system = "linux";
-  if (process.platform === "win32") {
-    system = "windows";
-  } else if (process.platform === "darwin") {
-    system = "macos";
-  }
-
-  // Setup paths and terminal
-  paths(globalPath,system,context);
-  //output.show();
-
-  workspaceContainsProjectPros().then((value) => {
-    vscode.commands.executeCommand("setContext", "pros.isPROSProject", value);
+  workspaceContainsProjectPros().then((isProsProject) => {
+    vscode.commands.executeCommand("setContext", "pros.isPROSProject", isProsProject);
+    if (isProsProject) {
+      getProsTerminal(context).then((terminal) => {
+        terminal.sendText("pros build-compile-commands");
+      });
+    }
   });
-
-  //terminal.sendText("pros build-compile-commands");
 
   if (
     vscode.workspace
@@ -85,8 +76,6 @@ export function activate(context: vscode.ExtensionContext) {
   vscode.commands.registerCommand("pros.build&upload", async () => {
     analytics.sendAction("build&upload");
     await buildUpload();
-    // await vscode.commands.executeCommand("pros.build");
-    // await vscode.commands.executeCommand("pros.upload");
   });
 
   vscode.commands.registerCommand("pros.upload", async () => {
@@ -105,21 +94,20 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.commands.registerCommand("pros.clean", clean);
 
-  vscode.commands.registerCommand("pros.terminal", () => {
+  vscode.commands.registerCommand("pros.terminal", async () => {
     analytics.sendAction("serialterminal");
     try {
-      makeTerminal();
+      const terminal = await getProsTerminal(context);
       terminal.sendText("pros terminal");
       terminal.show();
-
     } catch(err: any) {
       vscode.window.showErrorMessage(err.message);
     }
   });
-  vscode.commands.registerCommand("pros.showterminal", () => {
+  vscode.commands.registerCommand("pros.showterminal", async () => {
     analytics.sendAction("showterminal");
     try {
-      makeTerminal();
+      const terminal = await getProsTerminal(context);
       terminal.show();
       vscode.window.showInformationMessage("PROS Terminal started!");
     } catch (err: any) {

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -7,7 +7,6 @@ var tar = require('tar-fs');
 import * as fs from 'fs';
 import { promisify } from "util";
 import * as stream from 'stream';
-import { paths } from './install';
 import * as path from 'path';
 export function download(context: vscode.ExtensionContext, downloadURL: string, storagePath: string, system: string) {
     const globalPath = context.globalStorageUri.fsPath;
@@ -147,8 +146,6 @@ export function download(context: vscode.ExtensionContext, downloadURL: string, 
             }
         }
         //vscode.window.showInformationMessage("Finished extracting: " + storagePath);
-        paths(globalPath, system, context);
     });
-    paths(globalPath, system, context);
     return true;
 }

--- a/src/one-click/installed.ts
+++ b/src/one-click/installed.ts
@@ -15,44 +15,39 @@ export async function getCliVersion(url: string) {
 }
 
 export async function getCurrentVersion(oneClickPath: string) {
-    var oc = false;
-    var versionint = -1;
     try {
         const { stdout, stderr } = await promisify(child_process.exec)(
         `"${oneClickPath}" --version`
         );
-        versionint = +(stdout.replace("pros, version ","").replace(/\./gi,""));
-        oc = true;
+        const versionint = +(stdout.replace("pros, version ","").replace(/\./gi,""));
+        return [versionint, true];
     } catch {
         try {
             const { stdout, stderr } = await promisify(child_process.exec)(
                 `pros --version`
             );
-            versionint = +(stdout.replace("pros, version ","").replace(/\./gi,""));
-        } catch(err) {
-            console.log(err);
+            const versionint = +(stdout.replace("pros, version ","").replace(/\./gi,""));
+            return [versionint, false];
+        } catch (err) {
+            console.log(`Error fetching PROS CLI version: ${err}`);
+            return [-1, false];
         }
     }
-    return [versionint, oc];
 }
 
 export async function getInstallPromptTitle(oneClickPath: string) {
-    var title = "You do not have the PROS CLI installed. Install it now? (Recommended).";
     const recent = +(await getCliVersion('https://api.github.com/repos/purduesigbots/pros-cli/releases/latest')).replace(/\./gi,"");
     const [version, oneClicked] = await getCurrentVersion(oneClickPath);
 
-    if(oneClicked) {
-        if(version >= recent) {
-            title = "PROS is up to date!";
-        } else {
-            title = "There is an update available! Would you like to update now?";
-        }
+    if (!oneClicked && version === -1) {
+        return "You do not have the PROS CLI installed. Install it now? (Recommended).";
+    } else if (oneClicked && version >= recent) {
+        return "PROS is up to date!";
+    } else if (oneClicked && version < recent) {
+        return "There is an update available! Would you like to update now?";
+    } else if (version >= recent) {
+        return "PROS detected but not installed with VSCode. Would you like to install using VSCode? (Recommended).";
     } else {
-        if(version >= recent) {
-            title = "PROS detected but not installed with VSCode. Would you like to install using VSCode? (Recommended).";
-        } else if(version < recent) {
-            title = "An outdated version of PROS was detected on your system, not installed through VS Code. Would you like to install the update with VS Code?";
-        }
+        return "An outdated version of PROS was detected on your system, not installed through VS Code. Would you like to install the update with VS Code?";
     }
-    return title;
 }


### PR DESCRIPTION
Fixed a few minor issues while poking around in my PROS install today:
- `compile-commands.json` is now generated when a PROS project is opened
- Race conditions with the environment variables are now fixed by lazily setting the variables when a PROS terminal is needed
- Clicking "Update PROS" when the CLI is not installed now shows the correct message.

~~These changes, however, do **NOT** fully solve the issue in #47. Running `pros build-compile-commands` has no effect when run against a project that has been successfully built and produces the message `make: Nothing to be done for 'quick'.` Creating a new project or opening an existing project without `compile-commands.json` will not currently produce a new `compile-commands.json` file. I can think of a few solutions to this:~~

- ~~Set the default behavior when invoking [project.compile](https://github.com/purduesigbots/pros-cli/blob/949ee7d0566c1af329d3e0b8ce2718457ba13627/pros/cli/conductor.py#L227) to produce the compile-commands file. This would enable the CLI to automatically create this file whenever a new project is created (using the default flags).~~
- ~~Rework the logic for `pros build-compile-commands` so that projects that have already been built generate the compile-commands file anyways.~~
- ~~Put a hack of sorts into the VSCode extension here so that, whenever a project is created or opened, we clean the project first and then run `pros build-compile-commands`.~~

~~Option 3 doesn't seem ideal to me, but would be the fastest way to get things working for users without a CLI version bump.~~

Closes #47, the section above was because I didn't realize I was missing a necessary flag for the project creation CLI command.