### PR TITLE
🐛One-Click Refactor and Improvements

### DIFF
--- a/media/projectPros.js
+++ b/media/projectPros.js
@@ -41,7 +41,6 @@
       errorContainer.style.display = "";
       return;
     }
-    console.log(json);
     errorContainer.style.display = "none";
 
     // Render the current settings

--- a/package.json
+++ b/package.json
@@ -104,6 +104,10 @@
       {
         "command": "pros.uninstall",
         "title": "PROS: Uninstall PROS"
+      },
+      {
+        "command": "pros.updatecli",
+        "title": "PROS: Update PROS CLI"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -108,6 +108,10 @@
       {
         "command": "pros.updatecli",
         "title": "PROS: Update PROS CLI"
+      },
+      {
+        "command": "pros.verify",
+        "title": "PROS: Verify PROS Installation"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import {
   configurePaths,
   uninstall,
   updateCLI,
+  cleanup
 } from "./one-click/install";
 import { TextDecoder, TextEncoder } from "util";
 let analytics: Analytics;
@@ -96,6 +97,14 @@ export function activate(context: vscode.ExtensionContext) {
     analytics.sendAction("uninstall");
     await uninstall(context);
   });
+  vscode.commands.registerCommand("pros.updatecli", async () => {
+    analytics.sendAction("updatecli");
+    await updateCLI(context);
+  });
+  vscode.commands.registerCommand("pros.verify", async () => {
+    analytics.sendAction("verify");
+    await cleanup(context);
+  });
   vscode.commands.registerCommand("pros.build&upload", async () => {
     analytics.sendAction("build&upload");
     await buildUpload();
@@ -106,10 +115,6 @@ export function activate(context: vscode.ExtensionContext) {
     await upload();
   });
 
-  vscode.commands.registerCommand("pros.updatecli", async () => {
-    analytics.sendAction("updatecli");
-    await updateCLI(context);
-  });
   vscode.commands.registerCommand("pros.build", async () => {
     analytics.sendAction("build");
     await build();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,11 +18,13 @@ import {
 } from "./commands";
 import { ProsProjectEditorProvider } from "./views/editor";
 import { Analytics } from "./ga";
-import { install, paths, uninstall } from "./one-click/install";
+import { install, paths, uninstall, updateCLI } from "./one-click/install";
 import { TextDecoder, TextEncoder } from "util";
 let analytics: Analytics;
 
 export var terminal : vscode.Terminal;
+export var system : string;
+export const output = vscode.window.createOutputChannel("PROS Output");
 
 export function makeTerminal() {
   
@@ -43,13 +45,12 @@ export function makeTerminal() {
 }
 
 
-export const output = vscode.window.createOutputChannel("PROS Output");
 export function activate(context: vscode.ExtensionContext) {
   analytics = new Analytics(context);
   const globalPath = context.globalStorageUri.fsPath;
   
   // Figure out operating system
-  var system = "linux";
+  system = "linux";
   if (process.platform === "win32") {
     system = "windows";
   } else if (process.platform === "darwin") {
@@ -93,6 +94,10 @@ export function activate(context: vscode.ExtensionContext) {
     await upload();
   });
 
+  vscode.commands.registerCommand("pros.updatecli", async() => {
+    analytics.sendAction("updatecli");
+    await updateCLI(context);
+  });
   vscode.commands.registerCommand("pros.build", async () => {
     analytics.sendAction("build");
     await build();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,7 +85,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.commands.registerCommand("pros.updatecli", async() => {
     analytics.sendAction("updatecli");
-    await installCLI(context);
+    await updateCLI(context);
   });
   vscode.commands.registerCommand("pros.build", async () => {
     analytics.sendAction("build");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ import {
 } from "./commands";
 import { ProsProjectEditorProvider } from "./views/editor";
 import { Analytics } from "./ga";
-import { install, paths, uninstall, updateCLI } from "./one-click/install";
+import { install, paths, uninstall, installCLI } from "./one-click/install";
 import { TextDecoder, TextEncoder } from "util";
 let analytics: Analytics;
 
@@ -96,7 +96,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.commands.registerCommand("pros.updatecli", async() => {
     analytics.sendAction("updatecli");
-    await updateCLI(context);
+    await installCLI(context);
   });
   vscode.commands.registerCommand("pros.build", async () => {
     analytics.sendAction("build");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,6 @@ export const getProsTerminal = async (
 
   await configurePaths(context);
 
-  console.log(process.env);
 
   return vscode.window.createTerminal({
     name: "PROS Terminal",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,8 @@ export const getProsTerminal = async (
 export function activate(context: vscode.ExtensionContext) {
   analytics = new Analytics(context);
 
+  configurePaths(context);
+
   workspaceContainsProjectPros().then((isProsProject) => {
     vscode.commands.executeCommand(
       "setContext",

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -9,16 +9,13 @@ import { promisify } from "util";
 import * as stream from 'stream';
 import { paths } from './install';
 import * as path from 'path';
-export function download(context: vscode.ExtensionContext, downloadURL: string, storagePath: string, system: string) {
+export async function download(context: vscode.ExtensionContext, downloadURL: string, storagePath: string, system: string) {
     const globalPath = context.globalStorageUri.fsPath;
     // Check if file type is .tar.bz or .zip
-    var bz2 = false;
-    if (downloadURL.includes(".bz2")) {
-        bz2 = true;
-    }
-    window.withProgress({
+    const bz2 = downloadURL.includes(".bz2");
+    await window.withProgress({
         location: ProgressLocation.Notification,
-        title: "Installing: " + storagePath,
+        title: "Downloading: " + storagePath,
         cancellable: true
     }, async (progress, token) => {
         token.onCancellationRequested(() => {
@@ -37,118 +34,136 @@ export function download(context: vscode.ExtensionContext, downloadURL: string, 
                 progress.report({ increment: read / size });
             });
             // Write file contents to "sigbots.pros/download/filename.tar.bz2"
-            const out = fs.createWriteStream(globalPath + '/download/' + storagePath);
+            const out = fs.createWriteStream(path.join(globalPath, 'download', storagePath));
             await promisify(stream.pipeline)(response.body, out).catch(e => {
                 // Clean up the partial file if the download failed.
-                fs.unlink(globalPath + '/download/' + storagePath, (_) => null); // Don't wait, and ignore error.
+                fs.unlink(path.join(globalPath, 'download', storagePath), (_) => null); // Don't wait, and ignore error.
                 throw e;
             });
-            if (bz2) {
-                vscode.window.showInformationMessage("Extracting bz2: " + storagePath);
-                // Read the contents of the bz2 file
-                var compressedData = fs.readFileSync(globalPath + '/download/' + storagePath);
-                // Decrypt the bz2 file contents.
-                var data = bunzip.decode(compressedData);
-                storagePath = storagePath.replace(".bz2", "");
-                fs.writeFileSync(globalPath + '/download/' + storagePath, data);
-                // Write contents of the decrypted bz2 into "sigbots.pros/download/filename.tar"
-                fs.createReadStream(globalPath + '/download/' + storagePath).pipe(tar.extract(globalPath + '/install/'))
-                    .on('finish', function () {
-                        /*
-                        The linux and mac toolchain are both .tar.bz2 files,
-                        the cli and toolchain are downloaded together,
-                        and the cli is smaller in size meaning it should finish extracting first.
-                        Therefore, we should be able to chmod the downloaded cli files
-                        Once the toolchain extraction completes.
-                        We also need to rename the extracted toolchain from "gcc-arm-none-eabi-version_number"
-                        to "pros-toolchain-system"
-                        */
-                        console.log("Extracted");
-                        fs.readdir(globalPath + '/install/', (err, files) => {
-                            files.forEach(file => {
-                                if (file.includes("pros-cli-linux")) {
-                                    //chmod the files that linux needs chmodded
-                                    fs.chmodSync(path.join(globalPath, "install", file, "pros"), 0o751);
-                                    console.log(`Chmod ${path.join(globalPath, "install", file, "pros")}`);
-                                    fs.chmodSync(path.join(globalPath, "install", file, "intercept-c++"), 0o751);
-                                    fs.chmodSync(path.join(globalPath, "install", file, "intercept-cc"), 0o751);
-                                } else if (file.includes("pros-cli-macos")) {
-                                    //chmod the files that mac needs chmodded
-                                    fs.readdir(globalPath + '/install/pros-cli-macos/lib/', (err, libFiles) => {
-                                        libFiles.forEach(exec => {
-                                            if (exec.endsWith(".so")) {
-                                                fs.chmodSync(path.join(globalPath, "install", "pros-cli-macos", "lib"), 0o751);
-                                            }
-                                        });
-                                    });
-
-                                    fs.chmodSync(path.join(globalPath, "install", file, "pros"), 0o751);
-                                    fs.chmodSync(path.join(globalPath, "install", file, "intercept-c++"), 0o751);
-                                    fs.chmodSync(path.join(globalPath, "install", file, "intercept-cc"), 0o751);
-                                } else if (!file.includes("pros-cli-")) {
-                                    // Rename the extracted toolchain to the proper name
-                                    storagePath = storagePath.replace(".tar", "");
-                                    fs.renameSync(globalPath + '/install/' + file, globalPath + '/install/' + storagePath);
-                                }
-                            });
-                        });
-                    });
-                //vscode.window.showInformationMessage("Finished extracting bz2: " + storagePath);
-            } else {
-                vscode.window.showInformationMessage("Extracting: " + storagePath);
-                fs.createReadStream(globalPath + '/download/' + storagePath).pipe(unzipper.Extract({ path: globalPath + '/install/' + storagePath.replace(".zip", "") }))
-                    .on('finish', function () {
-                        if (storagePath.includes('pros-toolchain-windows')) {
-                            // create tmp folder
-                            console.log("Creating tmp folder on windows");
-                            fs.mkdirSync(path.join(globalPath, "install", "pros-toolchain-windows", "tmp"));
-                            console.log("Extracting GCC ARM contents to main folder");
-                            // extract contents of gcc-arm-none-eabi-version folder
-                            fs.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr"), (err, files) => {
-                                files.forEach(dir => {
-                                    if (dir.includes("gcc-arm-none")) {
-                                        // iterate through each folder in gcc-arm-none-eabi-version
-                                        fs.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir), (error, folders) => {
-                                            folders.forEach(folder => {
-                                                if (!folder.includes("arm-none")) {
-                                                    fs.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder), (errorsub, subfiles) => {
-                                                        // console.log(`Copying ${folder} folder`);
-                                                        // extract each file in subfolder
-                                                        subfiles.forEach(subfile => {
-                                                            var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder, subfile);
-                                                            var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder, subfile);
-                                                            fs.renameSync(originalPath, newPath);
-                                                        });
-                                                        if (errorsub) {
-                                                            throw errorsub;
-                                                        }
-                                                    });
-                                                } else {
-                                                    console.log("Copying arm-none-eabi folder");
-                                                    var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder);
-                                                    var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder);
-                                                    fs.renameSync(originalPath, newPath);
-                                                }
-                                            });
-                                            if (error) {
-                                                throw error;
-                                            }
-                                        });
-                                        fs.rmdirSync(dir, { recursive: true });
+        }
+    }).then(() => {
+            window.withProgress({
+                location: ProgressLocation.Notification,
+                title: "Installing: " + storagePath,
+                cancellable: true
+            }, async (progress, token) => {
+                
+                token.onCancellationRequested(() => {
+                    console.log("User canceled the long running operation");
+                });
+                
+               await new Promise((resolve) => {
+                    if (bz2) {
+                        // Read the contents of the bz2 file
+                        var compressedData = fs.readFileSync(path.join(globalPath, 'download', storagePath));
+                        // Decrypt the bz2 file contents.
+                        var data = bunzip.decode(compressedData);
+                        storagePath = storagePath.replace(".bz2", "");
+                        fs.writeFileSync(path.join(globalPath, 'download', storagePath), data);
+                        // Write contents of the decrypted bz2 into "sigbots.pros/download/filename.tar"
+                        fs.createReadStream(path.join(globalPath, 'download', storagePath)).pipe(tar.extract(path.join(globalPath, 'install')))
+                        .on('finish', function () {
+                            fs.readdir(path.join(globalPath, 'install'), (err, files) => {
+                                files.forEach(file => {
+                                    if(!file.includes('pros-')) { 
+                                        storagePath = storagePath.replace(".tar", "");
+                                        fs.renameSync(path.join(globalPath, 'download', file), path.join(globalPath, 'install', storagePath));
                                     }
                                 });
-                                if (err) {
-                                    throw err;
-                                }
                             });
-                        }
-                        vscode.window.showInformationMessage("Finished extracting: " + storagePath);
-                    });
-            }
-        }
-        //vscode.window.showInformationMessage("Finished extracting: " + storagePath);
+                        });
+                    //vscode.window.showInformationMessage("Finished extracting bz2: " + storagePath);
+                    } else {
+                        fs.createReadStream(globalPath + '/download/' + storagePath).pipe(unzipper.Extract({ path: globalPath + '/install/' + storagePath.replace(".zip", "") }))
+                        .on('finish', function () {
+
+                            if (storagePath.includes('pros-toolchain-windows')) {
+                                // create tmp folder
+                                console.log("Creating tmp folder on windows");
+                                fs.mkdirSync(path.join(globalPath, "install", "pros-toolchain-windows", "tmp"));
+                                console.log("Extracting GCC ARM contents to main folder");
+                                // extract contents of gcc-arm-none-eabi-version folder
+                                fs.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr"), (err, files) => {
+                                    for(const dir in files) {
+                                        if (dir.includes("gcc-arm-none")) {
+                                            // iterate through each folder in gcc-arm-none-eabi-version
+                                            fs.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir), (error, folders) => {
+                                                for(const folder in folders) {
+                                                    if (!folder.includes("arm-none")) {
+                                                        fs.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder), (errorsub, subfiles) => {
+                                                            // console.log(`Copying ${folder} folder`);
+                                                            // extract each file in subfolder
+                                                            for(const subfile in subfiles) {
+                                                                var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder, subfile);
+                                                                var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder, subfile);
+                                                                fs.renameSync(originalPath, newPath);
+                                                            }
+                                                            if (errorsub) {
+                                                                throw new Error("error");
+                                                            }
+                                                        });
+                                                    } else {
+                                                        console.log("Copying arm-none-eabi folder");
+                                                        var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder);
+                                                        var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder);
+                                                        fs.renameSync(originalPath, newPath);
+                                                    }
+                                                }
+                                                if (error) {
+                                                    throw new Error("error");
+                                                }
+                                            });
+                                            fs.rmdirSync(dir, { recursive: true });
+                                        }
+                                    }
+                                    if (err) {
+                                        throw new Error("error");
+                                    }
+                                });
+                            }
+                        });
+                    }
+                resolve("hahahah");
+               });
+                //stuff().then((v) => resolve(v));/*.finally(() => window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`))
+                //.catch(err => console.log(err));
+                //window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`);
+                //*/
+                });
+            
+        }).then(() => window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`));
+        console.log("chmodding");
+        chmod(globalPath, system);
         paths(globalPath, system, context);
-    });
-    paths(globalPath, system, context);
+    //window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`);
     return true;
+}
+
+export function chmod(globalPath : string, system : string) {
+    if (system === "windows") {
+        return
+    }
+    
+    fs.readdir(path.join(globalPath,'install'), (err, files) => {
+        files.forEach(file => {
+            if (file.includes("pros-cli-macos")) {
+                //chmod the files the so files on mac
+                fs.chmodSync(path.join(globalPath,'install','pros-cli-macos','lib','*.so'), 0o751);
+                /*
+                fs.readdir(globalPath + '/install/pros-cli-macos/lib/', (err, libFiles) => {
+                    libFiles.forEach(exec => {
+                        if (exec.endsWith(".so")) {
+                            fs.chmodSync(path.join(globalPath, "install", "pros-cli-macos", "lib"), 0o751);
+                        }
+                    });
+                });
+                */
+            }
+
+            // Chmod the executables (pros and intercepts)
+            fs.chmodSync(path.join(globalPath, "install", file, "pros"), 0o751);
+            fs.chmodSync(path.join(globalPath, "install", file, "intercept-c++"), 0o751);
+            fs.chmodSync(path.join(globalPath, "install", file, "intercept-cc"), 0o751);
+        });
+    });
 }

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -103,28 +103,28 @@ export async function extract(globalPath: string, downloadURL: string, storagePa
                 console.log("Extracting GCC ARM contents to main folder");
                 // extract contents of gcc-arm-none-eabi-version folder
                 const files = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr"));
-                    for(const dir in files) {
-                        if (dir.includes("gcc-arm-none")) {
-                            // iterate through each folder in gcc-arm-none-eabi-version
-                            const folders = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir));
-                                for(const folder in folders) {
-                                    if (!folder.includes("arm-none")) {
-                                        const subfiles = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder));
-                                        // extract everything back 1 level into their respective folder
-                                        for(const subfile in subfiles) {
-                                            console.log("third read dir for");
-                                            var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder, subfile);
-                                            var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder, subfile);
-                                            await fs.promises.rename(originalPath, newPath);
-                                        }
-                                    } else {
-                                        // move arm-none folder contents into a new directory under usr
-                                        console.log("Copying arm-none-eabi folder");
-                                        var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder);
-                                        var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder);
+                for(const dir in files) {
+                    if (dir.includes("gcc-arm-none")) {
+                        // iterate through each folder in gcc-arm-none-eabi-version
+                        const folders = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir));
+                            for(const folder in folders) {
+                                if (!folder.includes("arm-none")) {
+                                    const subfiles = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder));
+                                    // extract everything back 1 level into their respective folder
+                                    for(const subfile in subfiles) {
+                                        console.log("third read dir for");
+                                        var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder, subfile);
+                                        var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder, subfile);
                                         await fs.promises.rename(originalPath, newPath);
                                     }
+                                } else {
+                                    // move arm-none folder contents into a new directory under usr
+                                    console.log("Copying arm-none-eabi folder");
+                                    var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder);
+                                    var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder);
+                                    await fs.promises.rename(originalPath, newPath);
                                 }
+                            }
                             await fs.promises.rmdir(dir, { recursive: true });
                         }
                     }

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -172,15 +172,19 @@ export async function cleanup(context: vscode.ExtensionContext, system: string) 
 
 export async function chmod(globalPath : string, system : string) {
     if (system === "windows") {
-        return
+        return;
     }
     
-    const files = await fs.promises.readdir(path.join(globalPath,'install'))
+    const files = await fs.promises.readdir(path.join(globalPath,'install'));
     for(const file of files) {
         if (file.includes("pros-cli-macos")) {
-            //chmod the files the so files on mac
+            //chmod the files the .so files on mac
             await fs.promises.chmod(path.join(globalPath,'install','pros-cli-macos','lib','*.so'), 0o751);
             /*
+
+            This is the old code that just spammed chmod on the lib folder. If the code
+            above doesn't work then revert to this
+
                 fs.readdir(globalPath + '/install/pros-cli-macos/lib/', (err, libFiles) => {
                 libFiles.forEach(exec => {
                     if (exec.endsWith(".so")) {
@@ -192,8 +196,9 @@ export async function chmod(globalPath : string, system : string) {
         }
 
         // Chmod the executables (pros and intercepts)
-        await fs.promises.chmod(path.join(globalPath, "install", file, "pros"), 0o751);
-        await fs.promises.chmod(path.join(globalPath, "install", file, "intercept-c++"), 0o751);
-        await fs.promises.chmod(path.join(globalPath, "install", file, "intercept-cc"), 0o751);
     }
+    
+    await fs.promises.chmod(path.join(globalPath, "install", `pros-cli-${system}`, "pros"), 0o751);
+    await fs.promises.chmod(path.join(globalPath, "install", `pros-cli-${system}`, "intercept-c++"), 0o751);
+    await fs.promises.chmod(path.join(globalPath, "install", `pros-cli-${system}`, "intercept-cc"), 0o751);
 }

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -7,7 +7,6 @@ var tar = require('tar-fs');
 import * as fs from 'fs';
 import { promisify } from "util";
 import * as stream from 'stream';
-import * as child_process from "child_process";
 import { paths } from './install';
 import * as path from 'path';
 export function download(context: vscode.ExtensionContext, downloadURL: string, storagePath: string, system: string) {

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -118,7 +118,6 @@ export async function extract(
         );
 
         for (const file of files) {
-          console.log(file);
           if (file.includes("toolchain")) {
             const interfiles = await fs.promises.readdir(
               path.join(globalPath, "install", file)

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -7,9 +7,151 @@ var tar = require('tar-fs');
 import * as fs from 'fs';
 import { promisify } from "util";
 import * as stream from 'stream';
-import { paths } from './install';
+import { paths, PATH_SEP } from './install';
 import * as path from 'path';
-export async function download(context: vscode.ExtensionContext, downloadURL: string, storagePath: string, system: string) {
+
+//const delay = ms => new Promise(res => setTimeout(res, ms));
+
+async function download(globalPath: string, downloadURL: string, storagePath: string, system: string) {
+    console.log("start download");
+    // Check if file type is .tar.bz or .zip
+    const bz2 = downloadURL.includes(".bz2");
+    await window.withProgress({
+        location: ProgressLocation.Notification,
+        title: "Downloading: " + storagePath,
+        cancellable: true
+    }, async (progress, token) => {
+        token.onCancellationRequested(() => {
+            console.log("User canceled the long running operation");
+        });
+        // Fetch the file to download
+        const response = await fetch(downloadURL);
+        progress.report({ increment: 0 });
+        if (!response.ok) {
+            throw new Error(`Failed to download $url`);
+        } else if (response.body) {
+            const size = Number(response.headers.get('content-length'));
+            let read = 0;
+            response.body.on('data', (chunk: Buffer) => {
+                read += chunk.length;
+                progress.report({ increment: read / size });
+            });
+            // Write file contents to "sigbots.pros/download/filename.tar.bz2"
+            const out = fs.createWriteStream(path.join(globalPath, 'download', storagePath));
+            await promisify(stream.pipeline)(response.body, out).catch(e => {
+                // Clean up the partial file if the download failed.
+                fs.unlink(path.join(globalPath, 'download', storagePath), (_) => null); // Don't wait, and ignore error.
+                throw e;
+            });
+        }
+    })
+    return bz2
+}
+
+
+export async function extract(globalPath: string, downloadURL: string, storagePath: string, system: string, bz2: boolean) {
+    console.log("start extract");
+    await window.withProgress({
+        location: ProgressLocation.Notification,
+        title: "Installing: " + (storagePath.includes("cli") ? "PROS CLI" : "PROS Toolchain"),
+        cancellable: true
+    }, async (progress, token) => {
+        //progress.report({ increment: 0 });
+        
+        token.onCancellationRequested(() => {
+            console.log("User canceled the long running operation");
+        });
+        
+        if (bz2) {
+            // Read the contents of the bz2 file
+            var compressedData = fs.readFileSync(path.join(globalPath, 'download', storagePath));
+            // Decrypt the bz2 file contents.
+            var data = bunzip.decode(compressedData);
+            storagePath = storagePath.replace(".bz2", "");
+            fs.writeFileSync(path.join(globalPath, 'download', storagePath), data);
+            // Write contents of the decrypted bz2 into "sigbots.pros/download/filename.tar"
+            const read = fs.createReadStream(path.join(globalPath, 'download', storagePath));
+            await promisify(stream.pipeline)(read, tar.extract(path.join(globalPath, 'install', storagePath))).catch(e => {
+                fs.unlink(path.join(globalPath, 'install', storagePath), (_) => null); // Don't wait, and ignore error.
+                throw e;
+            });
+            const files = await fs.promises.readdir(path.join(globalPath, 'install'));
+            for(const file of files) {
+                if(!file.includes('pros-')) { 
+                    storagePath = storagePath.replace(".tar", "");
+                    await fs.promises.rename(path.join(globalPath, 'download', file), path.join(globalPath, 'install', storagePath));
+                }
+            }
+        //vscode.window.showInformationMessage("Finished extracting bz2: " + storagePath);
+        } else {
+            console.log("start not bz2");
+            //await fs.createReadStream(globalPath + '/download/' + storagePath).pipe(unzipper.Extract({ path: globalPath + '/install/' + storagePath.replace(".zip", "") }));
+            
+            // Create read stream of the zipped file
+            const read = fs.createReadStream(path.join(globalPath, 'download', storagePath));
+            storagePath=storagePath.replace(".zip","");
+            // await a promise of extracting the zip file
+            await promisify(stream.pipeline)(read, unzipper.Extract({path: path.join(globalPath, 'install', storagePath)})).catch(e => {
+                fs.unlink(path.join(globalPath, 'install', storagePath), (_) => null); // Don't wait, and ignore error.
+                throw e;
+            });
+
+            console.log("first on finish");
+            if (storagePath.includes('pros-toolchain-windows')) {
+                // create tmp folder
+                
+                console.log("Extracting GCC ARM contents to main folder");
+                // extract contents of gcc-arm-none-eabi-version folder
+                const files = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr"));
+                    for(const dir in files) {
+                        if (dir.includes("gcc-arm-none")) {
+                            // iterate through each folder in gcc-arm-none-eabi-version
+                            const folders = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir));
+                                for(const folder in folders) {
+                                    if (!folder.includes("arm-none")) {
+                                        const subfiles = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder));
+                                        // extract everything back 1 level into their respective folder
+                                        for(const subfile in subfiles) {
+                                            console.log("third read dir for");
+                                            var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder, subfile);
+                                            var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder, subfile);
+                                            await fs.promises.rename(originalPath, newPath);
+                                        }
+                                    } else {
+                                        // move arm-none folder contents into a new directory under usr
+                                        console.log("Copying arm-none-eabi folder");
+                                        var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder);
+                                        var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder);
+                                        await fs.promises.rename(originalPath, newPath);
+                                    }
+                                }
+                            await fs.promises.rmdir(dir, { recursive: true });
+                        }
+                    }
+
+                console.log("Creating tmp folder on windows");
+                await fs.promises.mkdir(path.join(globalPath, "install", "pros-toolchain-windows","tmp"));
+            }
+        }
+        console.log("end not bz2");
+    });
+
+    console.log("end extract");
+    return true;   
+}
+
+export async function downloadextract(context: vscode.ExtensionContext, downloadURL: string, storagePath: string, system: string) {
+    const globalPath = context.globalStorageUri.fsPath;
+    const bz2 = await download(globalPath, downloadURL, storagePath, system);
+    await extract(globalPath, downloadURL, storagePath, system, bz2)
+    console.log("done done done donda");
+    window.showInformationMessage(`Finished Installing ${storagePath}`);
+    
+    chmod(globalPath, system);
+    paths(globalPath, system, context);
+}
+/*
+export async function install(context: vscode.ExtensionContext, downloadURL: string, storagePath: string, system: string) {
     const globalPath = context.globalStorageUri.fsPath;
     // Check if file type is .tar.bz or .zip
     const bz2 = downloadURL.includes(".bz2");
@@ -128,7 +270,7 @@ export async function download(context: vscode.ExtensionContext, downloadURL: st
                 //stuff().then((v) => resolve(v));/*.finally(() => window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`))
                 //.catch(err => console.log(err));
                 //window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`);
-                //*/
+                //
                 });
             
         }).then(() => window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`));
@@ -139,6 +281,7 @@ export async function download(context: vscode.ExtensionContext, downloadURL: st
     return true;
 }
 
+*/
 export function chmod(globalPath : string, system : string) {
     if (system === "windows") {
         return

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -13,12 +13,11 @@ import * as path from 'path';
 //const delay = ms => new Promise(res => setTimeout(res, ms));
 
 async function download(globalPath: string, downloadURL: string, storagePath: string, system: string) {
-    console.log("start download");
     // Check if file type is .tar.bz or .zip
     const bz2 = downloadURL.includes(".bz2");
     await window.withProgress({
         location: ProgressLocation.Notification,
-        title: "Downloading: " + storagePath,
+        title: "Downloading: " + (storagePath.includes("cli") ? "PROS CLI" : "PROS Toolchain"),
         cancellable: true
     }, async (progress, token) => {
         token.onCancellationRequested(() => {
@@ -50,7 +49,6 @@ async function download(globalPath: string, downloadURL: string, storagePath: st
 
 
 export async function extract(globalPath: string, downloadURL: string, storagePath: string, system: string, bz2: boolean) {
-    console.log("start extract");
     await window.withProgress({
         location: ProgressLocation.Notification,
         title: "Installing: " + (storagePath.includes("cli") ? "PROS CLI" : "PROS Toolchain"),
@@ -58,20 +56,22 @@ export async function extract(globalPath: string, downloadURL: string, storagePa
     }, async (progress, token) => {
         //progress.report({ increment: 0 });
         
-        token.onCancellationRequested(() => {
+        token.onCancellationRequested((token) => {
             console.log("User canceled the long running operation");
         });
         
         if (bz2) {
             // Read the contents of the bz2 file
-            var compressedData = fs.readFileSync(path.join(globalPath, 'download', storagePath));
+            var compressedData = await fs.promises.readFile(path.join(globalPath, 'download', storagePath));
             // Decrypt the bz2 file contents.
-            var data = bunzip.decode(compressedData);
+            var data = await bunzip.decode(compressedData);
             storagePath = storagePath.replace(".bz2", "");
-            fs.writeFileSync(path.join(globalPath, 'download', storagePath), data);
+            await fs.promises.writeFile(path.join(globalPath, 'download', storagePath), data);
             // Write contents of the decrypted bz2 into "sigbots.pros/download/filename.tar"
             const read = fs.createReadStream(path.join(globalPath, 'download', storagePath));
             await promisify(stream.pipeline)(read, tar.extract(path.join(globalPath, 'install', storagePath))).catch(e => {
+                console.log("Error occured on extraction");
+                console.log(e);
                 fs.unlink(path.join(globalPath, 'install', storagePath), (_) => null); // Don't wait, and ignore error.
                 throw e;
             });
@@ -84,59 +84,56 @@ export async function extract(globalPath: string, downloadURL: string, storagePa
             }
         //vscode.window.showInformationMessage("Finished extracting bz2: " + storagePath);
         } else {
-            console.log("start not bz2");
             //await fs.createReadStream(globalPath + '/download/' + storagePath).pipe(unzipper.Extract({ path: globalPath + '/install/' + storagePath.replace(".zip", "") }));
             
             // Create read stream of the zipped file
             const read = fs.createReadStream(path.join(globalPath, 'download', storagePath));
+            read.on('entry', (entry) => {
+                console.log(entry);
+            });
             storagePath=storagePath.replace(".zip","");
             // await a promise of extracting the zip file
             await promisify(stream.pipeline)(read, unzipper.Extract({path: path.join(globalPath, 'install', storagePath)})).catch(e => {
+                console.log("Error occured on extraction");
+                console.log(e);
                 fs.unlink(path.join(globalPath, 'install', storagePath), (_) => null); // Don't wait, and ignore error.
                 throw e;
             });
 
-            console.log("first on finish");
             if (storagePath.includes('pros-toolchain-windows')) {
                 // create tmp folder
-                
-                console.log("Extracting GCC ARM contents to main folder");
                 // extract contents of gcc-arm-none-eabi-version folder
                 const files = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr"));
-                for(const dir in files) {
+                for(const dir of files) {
                     if (dir.includes("gcc-arm-none")) {
                         // iterate through each folder in gcc-arm-none-eabi-version
                         const folders = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir));
-                            for(const folder in folders) {
-                                if (!folder.includes("arm-none")) {
-                                    const subfiles = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder));
-                                    // extract everything back 1 level into their respective folder
-                                    for(const subfile in subfiles) {
-                                        console.log("third read dir for");
-                                        var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder, subfile);
-                                        var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder, subfile);
-                                        await fs.promises.rename(originalPath, newPath);
-                                    }
-                                } else {
-                                    // move arm-none folder contents into a new directory under usr
-                                    console.log("Copying arm-none-eabi folder");
-                                    var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder);
-                                    var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder);
+                        for(const folder of folders) {
+                            if (!folder.includes("arm-none")) {
+                                const subfiles = await fs.promises.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder));
+
+                                // extract everything back 1 level into their respective folder
+                                for(const subfile of subfiles) {
+                                    var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder, subfile);
+                                    var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder, subfile);
                                     await fs.promises.rename(originalPath, newPath);
                                 }
+                            } else {
+                                // move arm-none folder contents into a new directory under usr
+                                var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder);
+                                var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder);
+                                await fs.promises.rename(originalPath, newPath);
                             }
-                            await fs.promises.rmdir(dir, { recursive: true });
                         }
+                        await fs.promises.rmdir(dir, { recursive: true });
                     }
+                }
 
-                console.log("Creating tmp folder on windows");
                 await fs.promises.mkdir(path.join(globalPath, "install", "pros-toolchain-windows","tmp"));
             }
         }
-        console.log("end not bz2");
     });
 
-    console.log("end extract");
     return true;   
 }
 
@@ -144,169 +141,47 @@ export async function downloadextract(context: vscode.ExtensionContext, download
     const globalPath = context.globalStorageUri.fsPath;
     const bz2 = await download(globalPath, downloadURL, storagePath, system);
     await extract(globalPath, downloadURL, storagePath, system, bz2)
-    console.log("done done done donda");
     window.showInformationMessage(`Finished Installing ${storagePath}`);
-    
-    chmod(globalPath, system);
-    paths(globalPath, system, context);
-}
-/*
-export async function install(context: vscode.ExtensionContext, downloadURL: string, storagePath: string, system: string) {
-    const globalPath = context.globalStorageUri.fsPath;
-    // Check if file type is .tar.bz or .zip
-    const bz2 = downloadURL.includes(".bz2");
-    await window.withProgress({
-        location: ProgressLocation.Notification,
-        title: "Downloading: " + storagePath,
-        cancellable: true
-    }, async (progress, token) => {
-        token.onCancellationRequested(() => {
-            console.log("User canceled the long running operation");
-        });
-        // Fetch the file to download
-        const response = await fetch(downloadURL);
-        progress.report({ increment: 0 });
-        if (!response.ok) {
-            throw new Error(`Failed to download $url`);
-        } else if (response.body) {
-            const size = Number(response.headers.get('content-length'));
-            let read = 0;
-            response.body.on('data', (chunk: Buffer) => {
-                read += chunk.length;
-                progress.report({ increment: read / size });
-            });
-            // Write file contents to "sigbots.pros/download/filename.tar.bz2"
-            const out = fs.createWriteStream(path.join(globalPath, 'download', storagePath));
-            await promisify(stream.pipeline)(response.body, out).catch(e => {
-                // Clean up the partial file if the download failed.
-                fs.unlink(path.join(globalPath, 'download', storagePath), (_) => null); // Don't wait, and ignore error.
-                throw e;
-            });
-        }
-    }).then(() => {
-            window.withProgress({
-                location: ProgressLocation.Notification,
-                title: "Installing: " + storagePath,
-                cancellable: true
-            }, async (progress, token) => {
-                
-                token.onCancellationRequested(() => {
-                    console.log("User canceled the long running operation");
-                });
-                
-               await new Promise((resolve) => {
-                    if (bz2) {
-                        // Read the contents of the bz2 file
-                        var compressedData = fs.readFileSync(path.join(globalPath, 'download', storagePath));
-                        // Decrypt the bz2 file contents.
-                        var data = bunzip.decode(compressedData);
-                        storagePath = storagePath.replace(".bz2", "");
-                        fs.writeFileSync(path.join(globalPath, 'download', storagePath), data);
-                        // Write contents of the decrypted bz2 into "sigbots.pros/download/filename.tar"
-                        fs.createReadStream(path.join(globalPath, 'download', storagePath)).pipe(tar.extract(path.join(globalPath, 'install')))
-                        .on('finish', function () {
-                            fs.readdir(path.join(globalPath, 'install'), (err, files) => {
-                                files.forEach(file => {
-                                    if(!file.includes('pros-')) { 
-                                        storagePath = storagePath.replace(".tar", "");
-                                        fs.renameSync(path.join(globalPath, 'download', file), path.join(globalPath, 'install', storagePath));
-                                    }
-                                });
-                            });
-                        });
-                    //vscode.window.showInformationMessage("Finished extracting bz2: " + storagePath);
-                    } else {
-                        fs.createReadStream(globalPath + '/download/' + storagePath).pipe(unzipper.Extract({ path: globalPath + '/install/' + storagePath.replace(".zip", "") }))
-                        .on('finish', function () {
-
-                            if (storagePath.includes('pros-toolchain-windows')) {
-                                // create tmp folder
-                                console.log("Creating tmp folder on windows");
-                                fs.mkdirSync(path.join(globalPath, "install", "pros-toolchain-windows", "tmp"));
-                                console.log("Extracting GCC ARM contents to main folder");
-                                // extract contents of gcc-arm-none-eabi-version folder
-                                fs.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr"), (err, files) => {
-                                    for(const dir in files) {
-                                        if (dir.includes("gcc-arm-none")) {
-                                            // iterate through each folder in gcc-arm-none-eabi-version
-                                            fs.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir), (error, folders) => {
-                                                for(const folder in folders) {
-                                                    if (!folder.includes("arm-none")) {
-                                                        fs.readdir(path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder), (errorsub, subfiles) => {
-                                                            // console.log(`Copying ${folder} folder`);
-                                                            // extract each file in subfolder
-                                                            for(const subfile in subfiles) {
-                                                                var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder, subfile);
-                                                                var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder, subfile);
-                                                                fs.renameSync(originalPath, newPath);
-                                                            }
-                                                            if (errorsub) {
-                                                                throw new Error("error");
-                                                            }
-                                                        });
-                                                    } else {
-                                                        console.log("Copying arm-none-eabi folder");
-                                                        var originalPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", dir, folder);
-                                                        var newPath = path.join(globalPath, "install", "pros-toolchain-windows", "usr", folder);
-                                                        fs.renameSync(originalPath, newPath);
-                                                    }
-                                                }
-                                                if (error) {
-                                                    throw new Error("error");
-                                                }
-                                            });
-                                            fs.rmdirSync(dir, { recursive: true });
-                                        }
-                                    }
-                                    if (err) {
-                                        throw new Error("error");
-                                    }
-                                });
-                            }
-                        });
-                    }
-                resolve("hahahah");
-               });
-                //stuff().then((v) => resolve(v));/*.finally(() => window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`))
-                //.catch(err => console.log(err));
-                //window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`);
-                //
-                });
-            
-        }).then(() => window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`));
-        console.log("chmodding");
-        chmod(globalPath, system);
-        paths(globalPath, system, context);
-    //window.showInformationMessage(`Finished installing PROS ${storagePath.includes("cli") ? "CLI" : "Toolchain"}.`);
     return true;
 }
 
-*/
-export function chmod(globalPath : string, system : string) {
+export async function cleanup(context: vscode.ExtensionContext, system: string) {
+    await window.withProgress({
+        location: ProgressLocation.Notification,
+        title: "Finalizing Installation",
+        cancellable: true
+    }, async (progress, token) => {
+        const globalPath = context.globalStorageUri.fsPath;
+        await chmod(globalPath, system);
+        await paths(globalPath, system, context);
+        // Ensure that toolchain and cli are working
+    });
+}
+
+export async function chmod(globalPath : string, system : string) {
     if (system === "windows") {
         return
     }
     
-    fs.readdir(path.join(globalPath,'install'), (err, files) => {
-        files.forEach(file => {
-            if (file.includes("pros-cli-macos")) {
-                //chmod the files the so files on mac
-                fs.chmodSync(path.join(globalPath,'install','pros-cli-macos','lib','*.so'), 0o751);
-                /*
+    const files = await fs.promises.readdir(path.join(globalPath,'install'))
+    for(const file of files) {
+        if (file.includes("pros-cli-macos")) {
+            //chmod the files the so files on mac
+            await fs.promises.chmod(path.join(globalPath,'install','pros-cli-macos','lib','*.so'), 0o751);
+            /*
                 fs.readdir(globalPath + '/install/pros-cli-macos/lib/', (err, libFiles) => {
-                    libFiles.forEach(exec => {
-                        if (exec.endsWith(".so")) {
-                            fs.chmodSync(path.join(globalPath, "install", "pros-cli-macos", "lib"), 0o751);
-                        }
-                    });
+                libFiles.forEach(exec => {
+                    if (exec.endsWith(".so")) {
+                        fs.chmodSync(path.join(globalPath, "install", "pros-cli-macos", "lib"), 0o751);
+                    }
                 });
-                */
-            }
+            });
+            */
+        }
 
-            // Chmod the executables (pros and intercepts)
-            fs.chmodSync(path.join(globalPath, "install", file, "pros"), 0o751);
-            fs.chmodSync(path.join(globalPath, "install", file, "intercept-c++"), 0o751);
-            fs.chmodSync(path.join(globalPath, "install", file, "intercept-cc"), 0o751);
-        });
-    });
+        // Chmod the executables (pros and intercepts)
+        await fs.promises.chmod(path.join(globalPath, "install", file, "pros"), 0o751);
+        await fs.promises.chmod(path.join(globalPath, "install", file, "intercept-c++"), 0o751);
+        await fs.promises.chmod(path.join(globalPath, "install", file, "intercept-cc"), 0o751);
+    }
 }

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -5,10 +5,9 @@ var unzipper = require("unzipper");
 var bunzip = require("seek-bzip");
 var tar = require("tar-fs");
 import * as fs from "fs";
-import { promisify } from "util";
 import * as stream from "stream";
-import { configurePaths, PATH_SEP } from "./install";
 import * as path from "path";
+import { promisify } from "util";
 
 //const delay = ms => new Promise(res => setTimeout(res, ms));
 
@@ -299,26 +298,6 @@ export async function downloadextract(
   await extract(globalPath, downloadURL, storagePath, system, bz2);
   window.showInformationMessage(`Finished Installing ${storagePath}`);
   return true;
-}
-
-export async function cleanup(
-  context: vscode.ExtensionContext,
-  system: string
-) {
-  const globalPath = context.globalStorageUri.fsPath;
-  await window.withProgress(
-    {
-      location: ProgressLocation.Notification,
-      title: "Finalizing Installation",
-      cancellable: true,
-    },
-    async (progress, token) => {
-      await chmod(globalPath, system);
-      await configurePaths(context);
-      // Ensure that toolchain and cli are working
-    }
-  );
-  window.showInformationMessage("Installation Finalized!");
 }
 
 export async function chmod(globalPath: string, system: string) {

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -280,8 +280,11 @@ export async function cleanup(
       try {
         await chmod(globalPath, system);
         await configurePaths(context);
-
-        await removeDirAsync(path.join(globalPath, "download"), false);
+        /*
+         * The line commented below is causing a hang. 
+         * Probably something with the readStream in the extraction function...
+         */
+        // await removeDirAsync(path.join(globalPath, "download"), false);
       } catch(err) {
         console.log(err);
       }
@@ -291,7 +294,6 @@ export async function cleanup(
   // Ensure that toolchain and cli are working
   const cli_success = await verify_cli();
   const toolchain_success = await verify_toolchain();
-  
   console.log(cli_success);
   console.log(toolchain_success);
   if(cli_success && toolchain_success) {

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -232,7 +232,7 @@ export async function updateCLI(
       false
     );
   } catch (err) {
-    //console.log(err);
+    console.log(err);
   }
   var version = await getCliVersion(
     "https://api.github.com/repos/purduesigbots/pros-cli/releases/latest"
@@ -347,16 +347,12 @@ export async function configurePaths(context: vscode.ExtensionContext) {
 
 async function verify_cli() {
   var command = `pros c ls-templates --machine-output ${process.env["VSCODE FLAGS"]}`
-  console.log(command);
   const { stdout, stderr } = await promisify(child_process.exec)(
     command, { timeout: 30000 }
   );
-  console.log("CLI response : ");
-  //console.log(stdout);
   if(stderr) {
     console.log(stderr);
   }
-  //console.log(stdout.includes(`'kernel', 'version': '3.5.4'`))
   return stdout.includes(`'kernel', 'version': '3.5.4'`);
 }
 
@@ -368,17 +364,13 @@ async function verify_toolchain() {
 
   var gppPath = path.join(toolchain_path, "bin", "arm-none-eabi-g++");
   var command = `"${gppPath}" --version`
-
-  console.log(command);
   
   //return false;
   const { stdout, stderr } = await promisify(child_process.exec)(
     command, { timeout: 5000 }
   );
-  console.log("Toolchain resposne : ");
   if(stderr) {
     console.log(stderr);
   }
-  console.log(stdout);
   return stdout.startsWith(`arm-none-eabi-g++ (GNU Arm Embedded Toolchain`);
 }

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -4,7 +4,6 @@ import * as os from 'os';
 import { cleanup, downloadextract } from './download';
 import { getCurrentVersion, getCliVersion, getInstallPromptTitle } from "./installed";
 import * as fs from 'fs';
-import internal = require("stream");
 
 //TOOLCHAIN and CLI_EXEC_PATH are exported and used for running commands.
 export var TOOLCHAIN: string;
@@ -149,7 +148,7 @@ export async function install(context: vscode.ExtensionContext) {
                 downloadextract(context, downloadToolchain, toolchainName, system)
             ];
             const [a, b] = await Promise.all(promises);
-
+            await cleanup(context, system);
             // Delete the download subdirectory once everything is installed
 
             //await removeDirAsync(dirs.download,false);

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -1,15 +1,10 @@
 import * as vscode from "vscode";
 import * as path from 'path';
 import * as os from 'os';
-import { download } from './download';
+import { downloadextract } from './download';
 import { getCurrentVersion, getCliVersion, getInstallPromptTitle } from "./installed";
 import { makeTerminal, system } from '../extension'
 import * as fs from 'fs';
-import { promisify } from "util";
-import internal = require("stream");
-import { downloadDirToExecutablePath } from "vscode-test/out/util";
-import { ProsProjectEditorProvider } from "../views/editor";
-var fetch = require('node-fetch');
 
 //TOOLCHAIN and CLI_EXEC_PATH are exported and used for running commands.
 export var TOOLCHAIN: string;
@@ -23,7 +18,7 @@ a and b arguments are arrays in the format:
 {download_url, download_name, system_type}
 
 async function downloadCli_and_toolchain(context:vscode.ExtensionContext,a:string[],b:string[]) {
-download(context,a[0],a[1],a[2]);
+install(context,a[0],a[1],a[2]);
 await promisify(download)(context,b[0],b[1],b[2]);
 return true;
 }
@@ -140,8 +135,8 @@ export async function install(context: vscode.ExtensionContext) {
             */
 
             installCLI(context, true);
-            //download(context, downloadCli, cliName, system);
-            download(context, downloadToolchain, toolchainName, system);
+            //install(context, downloadCli, cliName, system);
+            downloadextract(context, downloadToolchain, toolchainName, system);
             // Delete the download subdirectory once everything is installed
 
             //await removeDirAsync(dirs.download,false);
@@ -196,7 +191,7 @@ export async function installCLI(context: vscode.ExtensionContext, force=false) 
     // Set the installed file names
     var cliName = `pros-cli-${system}.zip`;
     // Title of prompt depending on user's installed CLI
-    download(context, downloadCli, cliName, system);
+    downloadextract(context, downloadCli, cliName, system);
     //await paths(globalPath, system ,context);
     
 }

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -171,7 +171,7 @@ export async function install(context: vscode.ExtensionContext) {
     }
 }
 
-export async function installCLI(context: vscode.ExtensionContext, force=false) {
+export async function updateCLI(context: vscode.ExtensionContext, force=false) {
 
     const globalPath = context.globalStorageUri.fsPath;
     const system = getOperatingSystem();

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -170,8 +170,8 @@ export async function install(context: vscode.ExtensionContext) {
             await downloadCli_and_toolchain(context,cli_info,toolchain_info);
             */
       const promises = [
-        downloadextract(context, downloadCli, cliName, system),
-        downloadextract(context, downloadToolchain, toolchainName, system),
+        downloadextract(context, downloadCli, cliName),
+        downloadextract(context, downloadToolchain, toolchainName),
       ];
       await Promise.all(promises);
       await cleanup(context, system);
@@ -241,7 +241,7 @@ export async function updateCLI(
   // Set the installed file names
   var cliName = `pros-cli-${system}.zip`;
   // Title of prompt depending on user's installed CLI
-  await downloadextract(context, downloadCli, cliName, system);
+  await downloadextract(context, downloadCli, cliName);
   await cleanup(context, system);
   //await paths(globalPath, system ,context);
 }
@@ -267,13 +267,13 @@ async function createDirs(storagePath: string) {
 
 export async function cleanup(
   context: vscode.ExtensionContext,
-  system: string
+  system: string = getOperatingSystem()
 ) {
   const globalPath = context.globalStorageUri.fsPath;
   await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
-      title: "Finalizing Installation",
+      title: "Verifying Installation",
       cancellable: true,
     },
     async (progress, token) => {
@@ -297,7 +297,7 @@ export async function cleanup(
   console.log(cli_success);
   console.log(toolchain_success);
   if(cli_success && toolchain_success) {
-    vscode.window.showInformationMessage("Installation Successful!");
+    vscode.window.showInformationMessage("CLI and Toolchain are working!");
   } else {
     vscode.window.showErrorMessage(`${cli_success ? "" : "CLI"} ${!cli_success && !toolchain_success ? "" : "and"} ${toolchain_success ? "" : "Toolchain"} Installation Failed!`);
     vscode.window.showInformationMessage(`Please try installing again! If this problem persists, consider trying an alternative install method: https://pros.cs.purdue.edu/v5/getting-started/${system}.html`);

--- a/src/views/tree-view.ts
+++ b/src/views/tree-view.ts
@@ -8,7 +8,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
 	constructor() {
 		this.data = [new TreeItem('Quick Actions', [new TreeItem('Build & Upload', undefined, 'pros.build&upload'), new TreeItem('Upload', undefined, 'pros.upload'), new TreeItem('Build', undefined, 'pros.build'), new TreeItem('Clean', undefined, 'pros.clean'),new TreeItem('Brain Terminal', undefined, 'pros.terminal'),new TreeItem('Integrated Terminal', undefined, 'pros.showterminal')]),
 		new TreeItem('Conductor', [new TreeItem('Upgrade Project', undefined, 'pros.upgrade'), new TreeItem('Create Project', undefined, 'pros.new')]),
-		new TreeItem('Other',[new TreeItem('Install PROS', undefined, 'pros.install'),new TreeItem('Uninstall PROS', undefined, 'pros.uninstall'),new TreeItem('Update PROS CLI', undefined, 'pros.updatecli')])];
+		new TreeItem('Other',[new TreeItem('Install PROS', undefined, 'pros.install'),new TreeItem('Uninstall PROS', undefined, 'pros.uninstall'),new TreeItem('Update PROS CLI', undefined, 'pros.updatecli'), new TreeItem('Verify PROS Installation', undefined, 'pros.verify')])];
 	}
 
 	getTreeItem(element: TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {

--- a/src/views/tree-view.ts
+++ b/src/views/tree-view.ts
@@ -8,7 +8,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
 	constructor() {
 		this.data = [new TreeItem('Quick Actions', [new TreeItem('Build & Upload', undefined, 'pros.build&upload'), new TreeItem('Upload', undefined, 'pros.upload'), new TreeItem('Build', undefined, 'pros.build'), new TreeItem('Clean', undefined, 'pros.clean'),new TreeItem('Brain Terminal', undefined, 'pros.terminal'),new TreeItem('Integrated Terminal', undefined, 'pros.showterminal')]),
 		new TreeItem('Conductor', [new TreeItem('Upgrade Project', undefined, 'pros.upgrade'), new TreeItem('Create Project', undefined, 'pros.new')]),
-		new TreeItem('Other',[new TreeItem('Install PROS', undefined, 'pros.install'),new TreeItem('Uninstall PROS', undefined, 'pros.uninstall')])];
+		new TreeItem('Other',[new TreeItem('Install PROS', undefined, 'pros.install'),new TreeItem('Uninstall PROS', undefined, 'pros.uninstall'),new TreeItem('Update PROS CLI', undefined, 'pros.updatecli')])];
 	}
 
 	getTreeItem(element: TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {


### PR DESCRIPTION
#### Summary:
- Cleanup, rewrite, and separate code for improved readability and consistency.
- Fix the progress bar on download notification windows so that they actually align with progress.
- Change text on notification windows when installing PROS for more clarity on what is happening (and so that users don't try to start using commands before the installation completes and then complain that it doesn't work).
- Add verification portion of installation to chmod Linux and Mac files, set up environment variables, and test the installed cli and toolchain. Will notify the user if the installation was unsuccessful. The user can also call this portion again from the sidebar to verify their installation again if necessary

#### Motivation:
The initial release of one-click had many bugs, was inconsistent, and the notification windows did not accurately convey what was currently happening. VTOW support is not fun.

#### References:
#51 - Issues on windows and Linux seem to be resolved.
#45 - Doesn't solve our current cx_freeze issues, but will definitely help one-click's consistency on mac devices.

#### Test Plan:
I have tested this on multiple windows devices with success.

Thanks to @baylessj for help refactoring the code and testing changes

Thanks to @bradocchs for testing some of these changes on numerous Mac, Linux, and Windows devices.

It would be greatly appreciated if more people could help test these changes to make sure there are no issues. There have been a couple of small changes since a majority of the testing was done so in the following weeks I'm going to go through and make sure everything is still working properly.