### PR TITLE
✨Capture Screen Button

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,10 @@
         "title": "PROS: Integrated Terminal"
       },
       {
+        "command": "pros.capture",
+        "title": "PROS: Screenshot V5 Brain"
+      },
+      {
         "command": "pros.upgrade",
         "title": "PROS: Upgrade Project"
       },

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -48,18 +48,16 @@ const runCapture = async (output: string) => {
                 var command = `pros v5 capture ${output} --force ${process.env["VSCODE FLAGS"]} --machine-output`;
                 console.log(command);
                 const { stdout, stderr } = await promisify(child_process.exec)(
-                    command, { timeout: 30000 }
+                    command, { timeout: 6000,  maxBuffer: 1024 * 1024 * 10 }
                 );
                 let result = parseErrorMessage(stdout);
-                if (!(result===null)) {
+                if (!(result === "NOERROR")) {
                     throw new Error(result);
-                    return;
                 }
                 vscode.window.showInformationMessage("Capture saved!");
             }
             catch (error: any) {
-                console.log(error.stdout);
-                throw new Error(parseErrorMessage(error.stdout));
+                throw new Error(error);
             }
 
         }

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -1,0 +1,94 @@
+import * as vscode from "vscode";
+import * as child_process from "child_process";
+import * as path from "path";
+import * as fs from "fs";
+import { promisify } from "util";
+
+import { parseErrorMessage } from "./cli-parsing";
+
+const selectDirectory = async () => {
+    const directoryOptions: vscode.OpenDialogOptions = {
+      canSelectMany: false,
+      title: "Select a directory where the screenshot will be saved",
+      openLabel: "Save Screenshot Here",
+      canSelectFolders: true,
+      canSelectFiles: false,
+    };
+    const uri: string | undefined = await vscode.window
+      .showOpenDialog(directoryOptions)
+      .then((uri) => {
+        return uri ? uri[0].fsPath : undefined;
+      });
+    if (uri === undefined) {
+      throw new Error();
+    }
+    return uri;
+};
+
+const selectFileName = async () => {
+    let inputName: string | undefined;
+    const projectNameOptions: vscode.InputBoxOptions = {
+      prompt: "File Name",
+      placeHolder: "my-screenshot",
+    };
+    inputName = await vscode.window.showInputBox(projectNameOptions);
+    return (inputName ?  inputName : projectNameOptions.placeHolder) as string;
+};
+
+const runCapture = async (output: string) => {
+    await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: "Capturing image",
+          cancellable: false,
+        },
+        async (progress, token) => {
+            try {
+                // Command to run to clean project
+                var command = `pros v5 capture ${output} --force ${process.env["VSCODE FLAGS"]} --machine-output`;
+                console.log(command);
+                const { stdout, stderr } = await promisify(child_process.exec)(
+                    command, { timeout: 30000 }
+                );
+                let result = parseErrorMessage(stdout);
+                if (!(result===null)) {
+                    throw new Error(result);
+                    return;
+                }
+                vscode.window.showInformationMessage("Capture saved!");
+            }
+            catch (error: any) {
+                console.log(error.stdout);
+                throw new Error(parseErrorMessage(error.stdout));
+            }
+
+        }
+    );
+}
+
+
+export const capture = async () => {
+    let uri: string, fileName: string, output: string;
+    try {
+        uri = await selectDirectory();
+        fileName = await selectFileName();
+    }
+    catch (error) {
+        vscode.window.showErrorMessage("Error selecting output location");
+        return;
+    }
+    output = path.join(uri, fileName);
+    if (!output.endsWith(".png")) {
+        output += ".png";
+    }
+    try {
+        await runCapture(output);
+        await vscode.commands.executeCommand(
+            "vscode.openFolder",
+            vscode.Uri.file(output)
+          );
+    }
+    catch (error: any) {
+        vscode.window.showErrorMessage(error.message);
+    }
+}

--- a/src/commands/cli-parsing.ts
+++ b/src/commands/cli-parsing.ts
@@ -41,16 +41,16 @@ export const parseMakeOutput = (stdout: any) => {
 
 export const parseErrorMessage = (stdout: any) => {
   const errorSplit = stdout.split(/\r?\n/);
+  let err = "NOERROR";
   for (let e of errorSplit) {
     if (!e.startsWith(PREFIX)) {
       continue;
     }
     let jdata = JSON.parse(e.substr(PREFIX.length));
     if (jdata.type.startsWith("log") && jdata.level === "ERROR") {
-      console.log("An error occured");
       console.log(jdata.simpleMessage);
-      return jdata.simpleMessage;
+      err = jdata.simpleMessage;
     }
   }
-  return null;
+  return err;
 };

--- a/src/commands/cli-parsing.ts
+++ b/src/commands/cli-parsing.ts
@@ -47,7 +47,10 @@ export const parseErrorMessage = (stdout: any) => {
     }
     let jdata = JSON.parse(e.substr(PREFIX.length));
     if (jdata.type.startsWith("log") && jdata.level === "ERROR") {
+      console.log("An error occured");
+      console.log(jdata.simpleMessage);
       return jdata.simpleMessage;
     }
   }
+  return null;
 };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,3 +4,4 @@ export * from "./upload";
 export * from "./build";
 export * from "./clean";
 export * from "./buildUpload";
+export * from "./capture";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import {
   createNewProject,
   upgradeProject,
   upload,
+  capture,
 } from "./commands";
 import { ProsProjectEditorProvider } from "./views/editor";
 import { Analytics } from "./ga";
@@ -49,6 +50,8 @@ export const getProsTerminal = async (context: vscode.ExtensionContext): Promise
 export function activate(context: vscode.ExtensionContext) {
   analytics = new Analytics(context);
   
+  configurePaths(context);
+
   workspaceContainsProjectPros().then((isProsProject) => {
     vscode.commands.executeCommand("setContext", "pros.isPROSProject", isProsProject);
     if (isProsProject) {
@@ -115,6 +118,11 @@ export function activate(context: vscode.ExtensionContext) {
     }
   });
 
+  vscode.commands.registerCommand("pros.capture", async ()  => {
+    analytics.sendAction("capture");
+    await capture();
+  });
+  
   vscode.commands.registerCommand("pros.upgrade", () => {
     analytics.sendAction("upgrade");
     upgradeProject();

--- a/src/views/tree-view.ts
+++ b/src/views/tree-view.ts
@@ -6,7 +6,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
 	data: TreeItem[];
 
 	constructor() {
-		this.data = [new TreeItem('Quick Actions', [new TreeItem('Build & Upload', undefined, 'pros.build&upload'), new TreeItem('Upload', undefined, 'pros.upload'), new TreeItem('Build', undefined, 'pros.build'), new TreeItem('Clean', undefined, 'pros.clean'),new TreeItem('Brain Terminal', undefined, 'pros.terminal'),new TreeItem('Integrated Terminal', undefined, 'pros.showterminal')]),
+		this.data = [new TreeItem('Quick Actions', [new TreeItem('Build & Upload', undefined, 'pros.build&upload'), new TreeItem('Upload', undefined, 'pros.upload'), new TreeItem('Build', undefined, 'pros.build'), new TreeItem('Clean', undefined, 'pros.clean'),new TreeItem('Brain Terminal', undefined, 'pros.terminal'),new TreeItem('Integrated Terminal', undefined, 'pros.showterminal'), new TreeItem('Capture Image', undefined, 'pros.capture')]),
 		new TreeItem('Conductor', [new TreeItem('Upgrade Project', undefined, 'pros.upgrade'), new TreeItem('Create Project', undefined, 'pros.new')]),
 		new TreeItem('Other',[new TreeItem('Install PROS', undefined, 'pros.install'),new TreeItem('Uninstall PROS', undefined, 'pros.uninstall'),new TreeItem('Update PROS CLI', undefined, 'pros.updatecli')])];
 	}


### PR DESCRIPTION
Summary:
Allows users to capture a screenshot of the V5 brain and then display it within VSCode.

Motivation:
(Sort of) closes #35. Correct me if I'm wrong, but my understanding is that this was originally supposed to be within the CLI. It is a nice and simple feature to have in the extension though.

Test Plan:
- [x] Image saves to file path
- [x] Image opens after capture
- [x] Error appears if one occurred (Tested no V5 devices connected).