### PR TITLE
🚸Add clangd to extension dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,5 +227,8 @@
     "tar-fs": "^2.1.1",
     "universal-analytics": "^0.4.23",
     "unzipper": "^0.10.11"
-  }
+  },
+  "extensionDependencies": [
+    "llvm-vs-code-extensions.vscode-clangd"
+  ]
 }


### PR DESCRIPTION
#### Summary:
Many users have issues with IntelliSense showing errors that are not real. Installing the clangd extension will resolve these issues without the user having to configure anything.

#### Motivation:
vtow

#### Closes:
vtow

#### Test Plan:
- [x] Package the extension, install the pros extension, both pros and clangd are installed.