### PR TITLE
 ✨ Select PROS Project from directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pros",
-  "version": "0.1.1",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pros",
-      "version": "0.1.2",
+      "version": "0.3.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@purduesigbots/pros-cli-middleware": "^2.5.2",
@@ -6162,17 +6162,6 @@
         "tweetnacl": "~0.14.0"
       }
     },
-    "string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-      "dev": true,
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -6186,6 +6175,17 @@
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
+      }
+    },
+    "string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "onCommand:pros.welcome",
     "onCommand:pros.build&upload",
     "onView:prosTreeview",
-    "onCommand:vscode.openFolder"
+    "onCommand:pros.selectProject"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -119,8 +119,8 @@
         "title": "PROS: Verify PROS Installation"
       },
       {
-        "command": "vscode.openFolder",
-        "title": "Open The Folder Back Up"
+        "command": "pros.selectProject",
+        "title": "PROS: Select PROS Project"
       }
     ],
     "menus": {
@@ -173,8 +173,8 @@
           "command": "pros.install"
         },
         {
-          "when": "",
-          "command": "vscode.openFolder"
+          "when": "true",
+          "command": "pros.selectProject"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "onCommand:pros.new",
     "onCommand:pros.welcome",
     "onCommand:pros.build&upload",
-    "onView:prosTreeview"
+    "onView:prosTreeview",
+    "onCommand:vscode.openFolder"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -116,6 +117,10 @@
       {
         "command": "pros.verify",
         "title": "PROS: Verify PROS Installation"
+      },
+      {
+        "command": "vscode.openFolder",
+        "title": "Open The Folder Back Up"
       }
     ],
     "menus": {
@@ -166,6 +171,10 @@
         {
           "when": "pros.isPROSProject",
           "command": "pros.install"
+        },
+        {
+          "when": "",
+          "command": "vscode.openFolder"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,7 +126,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   vscode.commands.registerCommand("pros.clean", clean);
-
+  vscode.commands.registerCommand("pros.selectProject", chooseProject);
   vscode.commands.registerCommand("pros.terminal", async () => {
     analytics.sendAction("serialterminal");
     try {
@@ -393,6 +393,7 @@ async function chooseProject(){
   var array = await prosProjects();
   if(array.length === 0)
   {
+    vscode.window.showInformationMessage("No PROS Projects found in current directory!");
     return;
   }
   const targetOptions: vscode.QuickPickOptions = {
@@ -405,18 +406,13 @@ async function chooseProject(){
   {
     folderNames.push({label: f[0], description: ''});
   }
-  console.log(folderNames);
+  //console.log(folderNames);
   
+  // Display the options to users
   const target = await vscode.window.showQuickPick(
     folderNames,
     targetOptions
   );
-  while(!target)
-  {
-    const target = await vscode.window.showQuickPick(
-      folderNames,
-      targetOptions
-    );
   if (target === undefined) {
     throw new Error();
   }
@@ -425,7 +421,7 @@ async function chooseProject(){
     "vscode.openFolder",
     vscode.Uri.file(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath,target.label))
   );
-  }
+
 }
 
 //This function will return an array full of folder names containing pros project file

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,7 +76,7 @@ export function activate(context: vscode.ExtensionContext) {
       "pros.isPROSProject",
       isProsProject
     );
-
+    //This checks if user is currently working on a project, if not it allows user to select one
     if (isProsProject) {
       getProsTerminal(context).then((terminal) => {
        terminal.sendText("pros build-compile-commands");
@@ -381,7 +381,7 @@ async function workspaceContainsProjectPros(): Promise<boolean> {
   }
   return exists;
 }
-
+//This code calls prosProjects and allows user to choose which pros project to work on
 async function chooseProject(){
   if (
     vscode.workspace.workspaceFolders === undefined ||
@@ -397,30 +397,38 @@ async function chooseProject(){
   }
   const targetOptions: vscode.QuickPickOptions = {
     placeHolder: array[0].name,
-    title: "Select the target folder",
+    title: "Select the PROS project to work on",
   };
   var folderNames :Array<vscode.QuickPickItem>= [];
   //Specify type for any
   for(const f of array)
   {
-    folderNames.push({label: f[0], description: 'pros projects'});
+    folderNames.push({label: f[0], description: ''});
   }
   console.log(folderNames);
+  
   const target = await vscode.window.showQuickPick(
     folderNames,
     targetOptions
   );
+  while(!target)
+  {
+    const target = await vscode.window.showQuickPick(
+      folderNames,
+      targetOptions
+    );
   if (target === undefined) {
     throw new Error();
   }
+  //This will open the folder the user selects
   await vscode.commands.executeCommand(
     "vscode.openFolder",
     vscode.Uri.file(path.join(vscode.workspace.workspaceFolders[0].uri.fsPath,target.label))
   );
-  
+  }
 }
 
-
+//This function will return an array full of folder names containing pros project file
 async function prosProjects(){
   //Specify type for any later
   var array :any = [];


### PR DESCRIPTION
Summary:
This code allows user to choose which pros project to work on. When clicking the pros tap on VSC it will bring up a selection of folders the users can choose to work on. 

References:
Allow multiple pros projects in workspace (Issue #26)

Test Plan:
First open up a folder/directory that **does** contain a pros project folder in VSC. Then you can click the pros tab and check if the relevant folders show up for selection when the file selection pops up. Another test needed is to open up a folder/directory that **doesn't** contain a pros project folder. Then the file selection should show up but nothing should be available to select. 