### PR TITLE
✨🐛Fix Toolchain downloand and support custom urls.

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,6 +197,16 @@
           "type": "boolean",
           "default": true,
           "description": "Prompt for PROS CLI install on startup."
+        },
+        "pros.OneClick: CliDownloadURL": {
+          "type": "string",
+          "default": "default",
+          "description": "URL to download PROS CLI from. SHOULD NOT BE CHANGED BY MOST USERS!"
+        },
+        "pros.OneClick: ToolchainDownloadURL": {
+          "type": "string",
+          "default": "default",
+          "description": "URL to download PROS Toolchain from. SHOULD NOT BE CHANGED BY MOST USERS!"
         }
       }
     }

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -23,7 +23,7 @@ const runBuild = async () => {
     async (progress, token) => {
       try {
         // Command to run to build project
-        var command = `pros make --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["VSCODE FLAGS"]}`;
+        var command = `pros make --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
         console.log(command);
         console.log(process.env["PATH"]);
         const { stdout, stderr } = await promisify(child_process.exec)(

--- a/src/commands/buildUpload.ts
+++ b/src/commands/buildUpload.ts
@@ -21,7 +21,7 @@ const runBuildUpload = async () => {
     async (progress, token) => {
       try {
         // Command to run to build and upload project
-        var command = `pros mu --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["VSCODE FLAGS"]}`;
+        var command = `pros mu --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
         console.log(command);
         const { stdout, stderr } = await promisify(child_process.exec)(
           command,

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -46,7 +46,7 @@ const runCapture = async (output: string) => {
     async (progress, token) => {
       try {
         // Command to run to clean project
-        var command = `pros v5 capture ${output} --force ${process.env["VSCODE FLAGS"]} --machine-output`;
+        var command = `pros v5 capture ${output} --force ${process.env["PROS_VSCODE_FLAGS"]} --machine-output`;
         console.log(command);
         const { stdout, stderr } = await promisify(child_process.exec)(
           command,

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -20,7 +20,7 @@ const runClean = async () => {
     async (progress, token) => {
       try {
         // Command to run to clean project
-        var command = `pros make clean --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["VSCODE FLAGS"]}`;
+        var command = `pros make clean --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
         console.log(command);
         const { stdout, stderr } = await promisify(child_process.exec)(
           command,

--- a/src/commands/create-project.ts
+++ b/src/commands/create-project.ts
@@ -75,7 +75,7 @@ const selectProjectName = async () => {
  */
 const selectKernelVersion = async (target: string) => {
   // Command to run to fetch all kernel versions
-  var command = `pros c ls-templates --target ${target} --machine-output ${process.env["VSCODE FLAGS"]}`;
+  var command = `pros c ls-templates --target ${target} --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
   console.log(command);
   const { stdout, stderr } = await promisify(child_process.exec)(command, {
     env: {
@@ -140,7 +140,7 @@ const runCreateProject = async (
       try {
         // Command to run to make a new project with
         // user specified name, version, and location
-        var command = `pros c n "${projectPath}" ${target} ${version} --machine-output --build-cache ${process.env["VSCODE FLAGS"]}`;
+        var command = `pros c n "${projectPath}" ${target} ${version} --machine-output --build-cache ${process.env["PROS_VSCODE_FLAGS"]}`;
         console.log(command);
         const { stdout, stderr } = await promisify(child_process.exec)(
           command,

--- a/src/commands/upgrade-project.ts
+++ b/src/commands/upgrade-project.ts
@@ -17,7 +17,7 @@ const fetchTarget = async (): Promise<{
   curOkapi: string | undefined;
 }> => {
   // Command to run to fetch the current project that needs to be updated
-  var command = `pros c info-project --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["VSCODE FLAGS"]}`;
+  var command = `pros c info-project --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
   // console.log(command);
   const { stdout, stderr } = await promisify(child_process.exec)(command, {
     env: {
@@ -55,7 +55,7 @@ const fetchServerVersions = async (
   target: string
 ): Promise<{ newKernel: string; newOkapi: string | undefined }> => {
   // Command to run to fetch latest okapi and kernel versions
-  var command = `pros c q --target ${target} --machine-output ${process.env["VSCODE FLAGS"]}`;
+  var command = `pros c q --target ${target} --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
   // console.log(command);
   const { stdout, stderr } = await promisify(child_process.exec)(command, {
     env: {
@@ -91,7 +91,7 @@ const fetchServerVersions = async (
  */
 const runUpgrade = async () => {
   // Command to run to upgrade project to a newer version
-  var command = `pros c u --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["VSCODE FLAGS"]}`;
+  var command = `pros c u --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
   console.log(command);
   const { stdout, stderr } = await promisify(child_process.exec)(command, {
     encoding: "utf8",

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -31,7 +31,7 @@ const runUpload = async () => {
     async (progress, token) => {
       try {
         // Command to run to upload project to brain
-        var command = `pros u --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["VSCODE FLAGS"]}`;
+        var command = `pros u --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
         console.log(command);
         const { stdout, stderr } = await promisify(child_process.exec)(
           command,

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -86,7 +86,7 @@ async function getUrls(cliVersion: number, toolchainVersion: string) {
     // Set system, path seperator, and downloads to windows version
     downloadCli = `https://github.com/purduesigbots/pros-cli/releases/download/${cliVersion}/pros_cli-${cliVersion}-win-64bit.zip`;
     downloadToolchain =
-    `https://github.com/purduesigbots/toolchain/releases/download/${toolchainVersion}/pros-tooclhain-windows.zip`;
+    `https://github.com/purduesigbots/toolchain/releases/download/${toolchainVersion}/pros-toolchain-windows.zip`;
   } else if (getOperatingSystem() === "macos") {
     // Set system, path seperator, and downloads to windows version
     downloadCli = `https://github.com/purduesigbots/pros-cli/releases/download/${cliVersion}/pros_cli-${cliVersion}-macos-64bit.zip`;

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -338,9 +338,9 @@ export async function configurePaths(context: vscode.ExtensionContext) {
   CLI_EXEC_PATH = cliExecPath;
 
   // Prepend CLI and TOOLCHAIN to path
-  process.env["PATH"] = `${
+  process.env["PATH"] = `${PATH_SEP}${cliExecPath}${PATH_SEP}${path.join(toolchainPath, "bin")}${
     process.env["PATH"]
-  }${PATH_SEP}${cliExecPath}${PATH_SEP}${path.join(toolchainPath, "bin")}`;
+  }`;
 
   // Make PROS_TOOCLHAIN variable
   process.env["PROS_TOOLCHAIN"] = `${TOOLCHAIN}`;
@@ -349,7 +349,7 @@ export async function configurePaths(context: vscode.ExtensionContext) {
 }
 
 async function verifyCli() {
-  var command = `pros c ls-templates --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
+  var command = `pros c --help --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
   const { stdout, stderr } = await promisify(child_process.exec)(command, {
     timeout: 30000,
     env: {
@@ -361,7 +361,7 @@ async function verifyCli() {
     console.log(stderr);
   }
   console.log(stdout);
-  return stdout.includes(`'kernel', 'version': '3.5.4'`);
+  return stdout.includes(`Uc&42BWAaQ{"type": "log/message", "level": "DEBUG", "message": "DEBUG - pros:callback - CLI Version:`);
 }
 
 async function verifyToolchain() {
@@ -386,5 +386,5 @@ async function verifyToolchain() {
   if (stderr) {
     console.log(stderr);
   }
-  return stdout.replace(".exe","").startsWith(`arm-none-eabi-g++ (GNU Arm Embedded Toolchain`);
+  return stdout.replace(".exe","").startsWith(`arm-none-eabi-g++ (G`);
 }

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -333,7 +333,7 @@ export async function configurePaths(context: vscode.ExtensionContext) {
 
   PATH_SEP = getOperatingSystem() === "windows" ? ";" : ":";
 
-  TOOLCHAIN = toolchainPath;
+  TOOLCHAIN = isOneClickInstall?toolchainPath:(process.env["PROS_TOOLCHAIN"] ?? "");
   // Set CLI environmental variable file location
   CLI_EXEC_PATH = cliExecPath;
 

--- a/src/one-click/installed.ts
+++ b/src/one-click/installed.ts
@@ -3,7 +3,7 @@ import { promisify } from "util";
 import { getChildProcessPath } from "./path";
 var fetch = require("node-fetch");
 
-export async function getCliVersion(url: string) {
+export async function getCurrentReleaseVersion(url: string) {
   // Fetch the url
   const response = await fetch(url);
   if (!response.ok) {
@@ -11,7 +11,8 @@ export async function getCliVersion(url: string) {
     throw new Error(`Can't fetch release: ${response.statusText}`);
   }
   // Get the version number from the returned json
-  var vString = (await response.json()).tag_name;
+  const json = await response.json();
+  var vString = json.tag_name;
   return vString;
 }
 
@@ -55,7 +56,7 @@ export async function getCurrentVersion(oneClickPath: string) {
 
 export async function getInstallPromptTitle(oneClickPath: string) {
   const recent = +(
-    await getCliVersion(
+    await getCurrentReleaseVersion(
       "https://api.github.com/repos/purduesigbots/pros-cli/releases/latest"
     )
   ).replace(/\./gi, "");


### PR DESCRIPTION
This PR does two things:

1) It replaces the current windows toolchain URL (azure artifact that no longer exists) with a link to the most recent release on https://github.com/purduesigbots/toolchain, looking for the file `pros-toolchain-windows.zip`. Whenever we update the toolchain we need to make a new release on that repo and one-click will use that toolchain.

2) It allows users to put their own URLs for downloading the cli and toolchain. This allows more advanced users to refer to specific toolchain/cli versions, or do what #67 wants to do. 

This shouldn't be merged until we get a working toolchain onto the toolchain repo and test one-click on windows.