### PR TITLE
🐛Fix PATH Separator Issue

### DIFF
--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -309,13 +309,6 @@ export async function configurePaths(context: vscode.ExtensionContext) {
   const [cliExecPath, toolchainPath] = getIntegratedTerminalPaths(context);
 
   // return if the path is already configured
-  if (
-    process.env["PATH"]?.includes(cliExecPath) &&
-    process.env["PROS_TOOLCHAIN"]?.includes(toolchainPath)
-  ) {
-    console.log("path already configured");
-    return;
-  }
 
   const addQuotes = !(
     getOperatingSystem() === "macos" && !os.cpus()[0].model.includes("Apple M")
@@ -337,10 +330,15 @@ export async function configurePaths(context: vscode.ExtensionContext) {
   // Set CLI environmental variable file location
   CLI_EXEC_PATH = cliExecPath;
 
+  if (
+    process.env["PATH"]?.includes(cliExecPath) &&
+    process.env["PROS_TOOLCHAIN"]?.includes(TOOLCHAIN)
+  ) {
+    console.log("path already configured");
+    return;
+  }
   // Prepend CLI and TOOLCHAIN to path
-  process.env["PATH"] = `${PATH_SEP}${cliExecPath}${PATH_SEP}${path.join(toolchainPath, "bin")}${
-    process.env["PATH"]
-  }`;
+  process.env["PATH"] = `${cliExecPath}${PATH_SEP}${path.join(toolchainPath, "bin")}${PATH_SEP}${process.env["PATH"]}`;
 
   // Make PROS_TOOCLHAIN variable
   process.env["PROS_TOOLCHAIN"] = `${TOOLCHAIN}`;


### PR DESCRIPTION
The modified PATH started with the path separator and was then missing that path separator in between the toolchain and the original path. There was also a bug where it would modify the path twice. Not sure the extent of weird behavior this caused, but it will probably help at least a few users.