### PR TITLE
✨Add support for VexOS firmware updating

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,10 @@
       {
         "command": "pros.selectProject",
         "title": "PROS: Select PROS Project"
+      },
+      {
+        "command": "pros.updatefirmware",
+        "title": "PROS: Update VexOS Firmware"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,19 @@
     "url": "https://github.com/purduesigbots/pros-vsc.git"
   },
   "homepage": "http://pros.cs.purdue.edu",
-  "keywords": ["vex", "v5", "pros", "education", "outreach", "robotics", "vrc", "cortex", "code", "autonomous", "opcontrol"],
+  "keywords": [
+    "vex",
+    "v5",
+    "pros",
+    "education",
+    "outreach",
+    "robotics",
+    "vrc",
+    "cortex",
+    "code",
+    "autonomous",
+    "opcontrol"
+  ],
   "icon": "media/pros-tux-white.png",
   "galleryBanner": {
     "color": "#D6B872",
@@ -125,7 +137,7 @@
       },
       {
         "command": "pros.updatefirmware",
-        "title": "PROS: Update VexOS Firmware"
+        "title": "PROS: Update VEXos Firmware"
       }
     ],
     "menus": {

--- a/src/commands/fw-update.ts
+++ b/src/commands/fw-update.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+import * as child_process from "child_process";
+import { promisify } from "util";
+
+import { parseErrorMessage } from "./cli-parsing";
+import { getChildProcessPath } from "../one-click/path";
+
+export const updateFirmware = async () => {
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: "Updating Firmware",
+      cancellable: false,
+    },
+    async (progress, token) => {
+      try {
+        var command = `vexcom --help`; // TODO: set this to something real
+        const { stdout, stderr } = await promisify(child_process.exec)(
+          command,
+          {
+            encoding: "utf8",
+            maxBuffer: 1024 * 1024 * 50,
+            env: {
+              ...process.env,
+              PATH: getChildProcessPath(),
+            },
+          }
+        );
+
+        vscode.window.showInformationMessage("Project Uploaded!");
+      } catch (error: any) {
+        // Parse and display error message if one occured
+        await vscode.window.showErrorMessage(parseErrorMessage(error.stdout));
+      }
+    }
+  );
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,3 +5,4 @@ export * from "./build";
 export * from "./clean";
 export * from "./buildUpload";
 export * from "./capture";
+export * from "./fw-update";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,7 +162,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   vscode.commands.registerCommand("pros.updatefirmware", async () => {
-    analytics.sendAction("batterymedic");
+    analytics.sendAction("updatefirmware");
     await updateFirmware();
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -161,7 +161,7 @@ export function activate(context: vscode.ExtensionContext) {
     createNewProject();
   });
 
-  vscode.commands.registerCommand("pros.firmwareupdate", async () => {
+  vscode.commands.registerCommand("pros.updatefirmware", async () => {
     analytics.sendAction("batterymedic");
     await updateFirmware();
   });

--- a/src/views/tree-view.ts
+++ b/src/views/tree-view.ts
@@ -15,7 +15,6 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
         new TreeItem("Brain Terminal", undefined, "pros.terminal"),
         new TreeItem("Integrated Terminal", undefined, "pros.showterminal"),
         new TreeItem("Capture Image", undefined, "pros.capture"),
-		new TreeItem("Update VexOS", undefined, "pros.updatefirmware"),
       ]),
       new TreeItem("Conductor", [
         new TreeItem("Upgrade Project", undefined, "pros.upgrade"),
@@ -26,6 +25,7 @@ export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
         new TreeItem("Uninstall PROS", undefined, "pros.uninstall"),
         new TreeItem("Update PROS CLI", undefined, "pros.updatecli"),
         new TreeItem("Verify PROS Installation", undefined, "pros.verify"),
+        new TreeItem("Update VEXos", undefined, "pros.updatefirmware"),
       ]),
     ];
   }

--- a/src/views/tree-view.ts
+++ b/src/views/tree-view.ts
@@ -1,42 +1,65 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 export class TreeDataProvider implements vscode.TreeDataProvider<TreeItem> {
-	onDidChangeTreeData?: vscode.Event<TreeItem | null | undefined> | undefined;
+  onDidChangeTreeData?: vscode.Event<TreeItem | null | undefined> | undefined;
 
-	data: TreeItem[];
+  data: TreeItem[];
 
-	constructor() {
-		this.data = [new TreeItem('Quick Actions', [new TreeItem('Build & Upload', undefined, 'pros.build&upload'), new TreeItem('Upload', undefined, 'pros.upload'), new TreeItem('Build', undefined, 'pros.build'), new TreeItem('Clean', undefined, 'pros.clean'),new TreeItem('Brain Terminal', undefined, 'pros.terminal'),new TreeItem('Integrated Terminal', undefined, 'pros.showterminal'), new TreeItem('Capture Image', undefined, 'pros.capture')]),
-		new TreeItem('Conductor', [new TreeItem('Upgrade Project', undefined, 'pros.upgrade'), new TreeItem('Create Project', undefined, 'pros.new')]),
-		new TreeItem('Other',[new TreeItem('Install PROS', undefined, 'pros.install'),new TreeItem('Uninstall PROS', undefined, 'pros.uninstall'),new TreeItem('Update PROS CLI', undefined, 'pros.updatecli'), new TreeItem('Verify PROS Installation', undefined, 'pros.verify')])];
-	}
+  constructor() {
+    this.data = [
+      new TreeItem("Quick Actions", [
+        new TreeItem("Build & Upload", undefined, "pros.build&upload"),
+        new TreeItem("Upload", undefined, "pros.upload"),
+        new TreeItem("Build", undefined, "pros.build"),
+        new TreeItem("Clean", undefined, "pros.clean"),
+        new TreeItem("Brain Terminal", undefined, "pros.terminal"),
+        new TreeItem("Integrated Terminal", undefined, "pros.showterminal"),
+        new TreeItem("Capture Image", undefined, "pros.capture"),
+		new TreeItem("Update VexOS", undefined, "pros.updatefirmware"),
+      ]),
+      new TreeItem("Conductor", [
+        new TreeItem("Upgrade Project", undefined, "pros.upgrade"),
+        new TreeItem("Create Project", undefined, "pros.new"),
+      ]),
+      new TreeItem("Other", [
+        new TreeItem("Install PROS", undefined, "pros.install"),
+        new TreeItem("Uninstall PROS", undefined, "pros.uninstall"),
+        new TreeItem("Update PROS CLI", undefined, "pros.updatecli"),
+        new TreeItem("Verify PROS Installation", undefined, "pros.verify"),
+      ]),
+    ];
+  }
 
-	getTreeItem(element: TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
-		return element;
-	}
+  getTreeItem(element: TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+    return element;
+  }
 
-	getChildren(element?: TreeItem | undefined): vscode.ProviderResult<TreeItem[]> {
-		if (element === undefined) {
-			return this.data;
-		}
-		return element.children;
-	}
+  getChildren(
+    element?: TreeItem | undefined
+  ): vscode.ProviderResult<TreeItem[]> {
+    if (element === undefined) {
+      return this.data;
+    }
+    return element.children;
+  }
 }
 
 class TreeItem extends vscode.TreeItem {
-	children: TreeItem[] | undefined;
+  children: TreeItem[] | undefined;
 
-	constructor(label: string, children?: TreeItem[], command?: string,) {
-		super(
-			label,
-			children === undefined ? vscode.TreeItemCollapsibleState.None :
-				vscode.TreeItemCollapsibleState.Expanded);
-		if (command !== undefined) {
-			this.command = {
-				title: label,
-				command
-			};
-		}
-		this.children = children;
-	}
+  constructor(label: string, children?: TreeItem[], command?: string) {
+    super(
+      label,
+      children === undefined
+        ? vscode.TreeItemCollapsibleState.None
+        : vscode.TreeItemCollapsibleState.Expanded
+    );
+    if (command !== undefined) {
+      this.command = {
+        title: label,
+        command,
+      };
+    }
+    this.children = children;
+  }
 }

--- a/src/views/welcome-view.ts
+++ b/src/views/welcome-view.ts
@@ -49,21 +49,23 @@ export const fetchKernelVersion = async (): Promise<string> => {
 };
 
 export const fetchKernelVersionNonCLIDependent = async (): Promise<string> => {
-  const response = await fetch(
-    "https://api.github.com/repos/purduesigbots/pros/releases/latest"
-  );
-  if (!response.ok) {
-    console.log(response.url, response.status, response.statusText);
-    throw new Error(`Can't fetch kernel release: ${response.statusText}`);
-  }
-  var v = (await response.json()).tag_name;
-  return v;
+//   const response = await fetch(
+//     "https://api.github.com/repos/purduesigbots/pros/releases/latest"
+//   );
+//   if (!response.ok) {
+//     console.log(response.url, response.status, response.statusText);
+//     throw new Error(`Can't fetch kernel release: ${response.statusText}`);
+//   }
+//   var v = (await response.json()).tag_name;
+//   return v;
+return "0.0.0";
 };
 export const fetchCliVersion = async (): Promise<string> => {
-  const response = await axios.get(
-    "https://purduesigbots.github.io/pros-mainline/stable/UpgradeManifestV1.json"
-  );
-  return `${response.data.version.major}.${response.data.version.minor}.${response.data.version.patch}`;
+	return "0.0.0";
+//   const response = await axios.get(
+//     "https://purduesigbots.github.io/pros-mainline/stable/UpgradeManifestV1.json"
+//   );
+//   return `${response.data.version.major}.${response.data.version.minor}.${response.data.version.patch}`;
 };
 
 export function getWebviewContent(


### PR DESCRIPTION
Adds a command that runs `vexcom --vexos latest`. 

I've tested that the error message of "No device found" shows up correctly when running the command on my machine, but I don't have access to a V5 brain to test that this works fully.