### PR TITLE
get current workspace folder and PROS project slightly better.

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -1,7 +1,7 @@
 import * as child_process from "child_process";
 import * as vscode from "vscode";
 import { BackgroundProgress } from "../logger";
-
+import { get_cwd_is_pros } from "../workspace";
 /*
 
     I realize I missed something quite important in the presentation. It's the idea of synchronous v.s. asynchronous functions.
@@ -69,24 +69,7 @@ export class Base_Command {
     }
 
     validate_pros_project = async(): Promise<boolean> => {
-        // this function will check if the current directory is a pros project
-
-        // the easiest way to check this is by checking if a file called `project.pros` exists in the current working directory.
-        // if it does, then we are in a pros project, and we can return true
-        // a method of doing this can be seen on line 393 of src/extensions.ts. However, this method is not 100% reliable.
-        // This method assumes the 0th index of the workspaceFolders array is the current working directory, which may not always be the case according to documentation.
-        // Doing this could lead to problems if the user has multiple projects open at once.
-
-        // One thing you should look at doing is identifying the current working directory, and then checking if the file exists in that directory.
-        // A potential workaround for this is to do the following:
-        // identify a bash command that will return the current working directory
-        // use the child_process.exec() function to run that command
-        // parse the output of the command to get the current working directory
-        // check if the file exists in that directory
-
-        // if the file does not exist, then we can return false
-
-        return true;
+        return (await get_cwd_is_pros())[1];
     }
 
     run_command = async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,10 +30,11 @@ import {
   uninstall,
   cleanup
 } from "./one-click/install";
-
 import { getChildProcessPath, getChildProcessProsToolchainPath  } from "./one-click/path";
 import { TextDecoder, TextEncoder } from "util";
 import { Logger } from "./logger";
+import { get_cwd_is_pros } from "./workspace";
+
 let analytics: Analytics;
 
 export var system: string;
@@ -90,49 +91,6 @@ export const getProsTerminal = async (
     env: process.env,
   });
 };
-
-/*!
-  * @brief This function returns the current working directory (vscode.Uri) and if it is a pros project (boolean)
-  * @return [vscode.Uri, boolean]
-  * 
-  * @details This function firstly looks at the workspace for the active text editor. If there is no active text editor, it will use the 0th index of the workspace folders. 
-  * If there are no workspace folders, it will throw an error. If the workspace folder is a pros project, it will return the workspace folder and true. 
-  * If the workspace folder is not a pros project, it will return the workspace folder and false.
-  * 
-  */
-
-export const get_cwd_is_pros = async (): Promise<[vscode.Uri, boolean]> => {
-  //output the 0th workspace folder
-
-  let active = vscode.window.activeTextEditor?.document.uri ?? undefined;
-  let active_dir = undefined;
-
-  const filename_search = "project.pros";
-  let is_pros_project = true;
-
-
-  if(active !== undefined) {
-    console.log(`active: ${active}`);
-    active_dir = vscode.workspace.getWorkspaceFolder(active)?.uri;
-    console.log(`workspace folder: ${active_dir}`);
-  } else if(vscode.workspace.workspaceFolders !== undefined && vscode.workspace.workspaceFolders !== null) {
-      active_dir = vscode.workspace.workspaceFolders[0].uri;
-  } 
-
-  if(active_dir === undefined || active_dir === null) {
-    throw(new Error("No workspace folder found"));
-  }
-
-
-  // use fs to check if the active directory contains a project.pros file
-  try {
-    await vscode.workspace.fs.stat(vscode.Uri.joinPath(active_dir, filename_search));
-  } catch (err) {
-    is_pros_project = false;
-  }
-  return [active_dir, is_pros_project];
-
-}
 
 export function activate(context: vscode.ExtensionContext) {
   vscode.window.showInformationMessage("PROS extension activated");
@@ -460,6 +418,7 @@ export function deactivate() {
 async function workspaceContainsProjectPros(): Promise<boolean> {
   return ((await get_cwd_is_pros())[1]);
 }
+
 //This code calls prosProjects and allows user to choose which pros project to work on
 async function chooseProject() {
   if (

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,49 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import * as os from "os";
+
+/*!
+  * @brief This function returns the current working directory (vscode.Uri) and if it is a pros project (boolean)
+  * @return [vscode.Uri, boolean]
+  * 
+  * @details This function firstly looks at the workspace for the active text editor. If there is no active text editor, it will use the 0th index of the workspace folders. 
+  * If there are no workspace folders, it will throw an error. If the workspace folder is a pros project, it will return the workspace folder and true. 
+  * If the workspace folder is not a pros project, it will return the workspace folder and false.
+  * 
+  */
+
+export const get_cwd_is_pros = async (): Promise<[vscode.Uri, boolean]> => {
+    //output the 0th workspace folder
+  
+    let active = vscode.window.activeTextEditor?.document.uri ?? undefined;
+    let active_dir = undefined;
+  
+    const filename_search = "project.pros";
+    let is_pros_project = true;
+  
+  
+    if(active !== undefined) {
+      console.log(`active: ${active}`);
+      active_dir = vscode.workspace.getWorkspaceFolder(active)?.uri;
+      console.log(`workspace folder: ${active_dir}`);
+    } else if(vscode.workspace.workspaceFolders !== undefined && vscode.workspace.workspaceFolders !== null) {
+        active_dir = vscode.workspace.workspaceFolders[0].uri;
+    } 
+  
+    if(active_dir === undefined || active_dir === null) {
+      throw(new Error("No workspace folder found"));
+    }
+  
+  
+    // use fs to check if the active directory contains a project.pros file
+    try {
+      await vscode.workspace.fs.stat(vscode.Uri.joinPath(active_dir, filename_search));
+    } catch (err) {
+      is_pros_project = false;
+    }
+    return [active_dir, is_pros_project];
+  
+  }
+
+
+  


### PR DESCRIPTION
Does what the title says. Adds a method to attempt to get 1) the current workspace folder Uri and 2) if it is a PROS project or not. Firstly tries to get the active text editor, and if that does not work it uses the 0th index of workspace folders. throws an error if there are no workspace folders, so be sure to catch it.