### PR TITLE
🐛 Error handling for rate limit error

### DIFF
--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -160,15 +160,19 @@ export async function install(context: vscode.ExtensionContext) {
   await prosLogger.log("OneClick", `Operating System Detected: ${system}`);
 
   await prosLogger.log("OneClick", "Fetching Latest CLI Version....");
-  var cliVersion = (await getCurrentReleaseVersion(
-    "https://api.github.com/repos/purduesigbots/pros-cli/releases/latest"
-  ));
-  let release_version_number = +cliVersion.replace(/\./gi,'') ?? 0;
-  const toolchainVersion = await getCurrentReleaseVersion(
-    "https://api.github.com/repos/purduesigbots/toolchain/releases/latest"
-  )
-
-  await prosLogger.log("OneClick", `CLI Version: ${cliVersion}`);
+  try{
+    var cliVersion = ((await getCurrentReleaseVersion(
+      "https://api.github.com/repos/purduesigbots/pros-cli/releases/latest"
+    )));
+    let release_version_number = +cliVersion.replace(/\./gi,'') ?? 0;
+    const toolchainVersion = await getCurrentReleaseVersion(
+      "https://api.github.com/repos/purduesigbots/toolchain/releases/latest"
+    )
+    await prosLogger.log("OneClick", `CLI Version: ${cliVersion}`);
+  } catch(e: any) {
+    await prosLogger.log("OneClick", "Failed to access version number");
+    console.log("Hit the rate limit, please try again after some time.");
+  }
 
   // Get system type, path string separator, CLI download url, and toolchain download url.
   // Default variables are based on linux.


### PR DESCRIPTION
Added error handling for requests sent to webpages with rate limits so that the extension doesn't crash.

Closes #92. 