### PR TITLE
🐛Wait for configurePaths() to finish in activate()

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,12 +68,12 @@ export const getProsTerminal = async (
   });
 };
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   analytics = new Analytics(context);
 
   prosLogger = new Logger(context, "PROS_Extension_log", true, "useLogger");
 
-  configurePaths(context);
+  await configurePaths(context);
 
   workspaceContainsProjectPros().then((isProsProject) => {
     vscode.commands.executeCommand(


### PR DESCRIPTION
- make activate() async
- add an await to configurePaths() call in activate()
This way, we ensure the paths are configured correctly before running other commands that rely on the path e.g. checking if the cli is installed
Fixes #109 