### PR TITLE
Rewrote some sidebar commands to incorporate Base Command 

### DIFF
--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -1,13 +1,28 @@
 import * as vscode from "vscode";
-import * as child_process from "child_process";
 import * as path from "path";
-import * as fs from "fs";
-import { promisify } from "util";
 
-import { parseErrorMessage } from "./cli-parsing";
-import { getChildProcessPath } from "../one-click/path";
+import { Base_Command, Base_Command_Options } from "./base-command";
+import { selectDirectory , selectFileName} from "./command_tools";
 
-const selectDirectory = async () => {
+export const capture = async () => {
+  let dir = await selectDirectory("Select a directory where the screenshot will be saved");
+  let file = await selectFileName("Enter file name for the screenshot");
+
+  const capture_command_options: Base_Command_Options = {
+    command: "prosv5",
+    args: [
+      "capture",
+      `${path.join(dir, file)}`,
+      "--build-cache",
+      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
+    ],
+    message: "Capturing Screenshot",
+    requires_pros_project: true 
+  }
+
+const capture_command: Base_Command = new Base_Command(capture_command_options);
+
+/*const selectDirectory = async () => {
   const directoryOptions: vscode.OpenDialogOptions = {
     canSelectMany: false,
     title: "Select a directory where the screenshot will be saved",
@@ -93,4 +108,12 @@ export const capture = async () => {
   } catch (error: any) {
     vscode.window.showErrorMessage(error.message);
   }
+};*/
+
+try {
+  await capture_command.run_command();
+  await vscode.commands.executeCommand("vscode.openFolder", vscode.Uri.file(path.join(dir, file)));
+} catch (err: any) {
+  await vscode.window.showErrorMessage(err.message);
+}
 };

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -9,11 +9,11 @@ export const capture = async () => {
   let file = await selectFileName("Enter file name for the screenshot");
 
   const capture_command_options: Base_Command_Options = {
-    command: "prosv5",
+    command: "pros",
     args: [
+      "v5",
       "capture",
       `${path.join(dir, file)}`,
-      "--build-cache",
       ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
     ],
     message: "Capturing Screenshot",
@@ -22,97 +22,9 @@ export const capture = async () => {
 
 const capture_command: Base_Command = new Base_Command(capture_command_options);
 
-/*const selectDirectory = async () => {
-  const directoryOptions: vscode.OpenDialogOptions = {
-    canSelectMany: false,
-    title: "Select a directory where the screenshot will be saved",
-    openLabel: "Save Screenshot Here",
-    canSelectFolders: true,
-    canSelectFiles: false,
-  };
-  const uri: string | undefined = await vscode.window
-    .showOpenDialog(directoryOptions)
-    .then((uri) => {
-      return uri ? uri[0].fsPath : undefined;
-    });
-  if (uri === undefined) {
-    throw new Error();
-  }
-  return uri;
-};
-
-const selectFileName = async () => {
-  let inputName: string | undefined;
-  const projectNameOptions: vscode.InputBoxOptions = {
-    prompt: "File Name",
-    placeHolder: "my-screenshot",
-  };
-  inputName = await vscode.window.showInputBox(projectNameOptions);
-  return (inputName ? inputName : projectNameOptions.placeHolder) as string;
-};
-
-const runCapture = async (output: string) => {
-  await vscode.window.withProgress(
-    {
-      location: vscode.ProgressLocation.Notification,
-      title: "Capturing image",
-      cancellable: false,
-    },
-    async (progress, token) => {
-      try {
-        // Command to run to clean project
-        var command = `pros v5 capture ${output} --force ${process.env["PROS_VSCODE_FLAGS"]} --machine-output`;
-        console.log(command);
-        const { stdout, stderr } = await promisify(child_process.exec)(
-          command,
-          {
-            timeout: 6000,
-            maxBuffer: 1024 * 1024 * 10,
-            env: {
-              ...process.env,
-              PATH: getChildProcessPath(),
-            },
-          }
-        );
-        let result = parseErrorMessage(stdout);
-        if (!(result === "NOERROR")) {
-          throw new Error(result);
-        }
-        vscode.window.showInformationMessage("Capture saved!");
-      } catch (error: any) {
-        throw new Error(error);
-      }
-    }
-  );
-};
-
-export const capture = async () => {
-  let uri: string, fileName: string, output: string;
-  try {
-    uri = await selectDirectory();
-    fileName = await selectFileName();
-  } catch (error) {
-    vscode.window.showErrorMessage("Error selecting output location");
-    return;
-  }
-  output = path.join(uri, fileName);
-  if (!output.endsWith(".png")) {
-    output += ".png";
-  }
-  try {
-    await runCapture(output);
-    await vscode.commands.executeCommand(
-      "vscode.openFolder",
-      vscode.Uri.file(output)
-    );
-  } catch (error: any) {
-    vscode.window.showErrorMessage(error.message);
-  }
-};*/
-
 try {
   await capture_command.run_command();
-  await vscode.commands.executeCommand("vscode.openFolder", vscode.Uri.file(path.join(dir, file)));
+  await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(path.join(dir, file.replace(".png","")+ ".png")));
 } catch (err: any) {
   await vscode.window.showErrorMessage(err.message);
 }

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -1,16 +1,27 @@
 import * as vscode from "vscode";
-import * as child_process from "child_process";
-import { promisify } from "util";
+import { Base_Command } from "./base-command";
 
-import { parseErrorMessage } from "./cli-parsing";
-import { getChildProcessPath } from "../one-click/path";
+const runClean = async () => {
+  const cleanCommand = new Base_Command({
+    command: "pros",
+    args: [
+      "make",
+      "clean",
+      ...`${process.env.PROS_VSCODE_FLAGS}`.split(" ")
+    ],
+    message: "Cleaning Project",
+    requires_pros_project: true
+  });
+  await cleanCommand.run_command();
+};
+
 /**
  * Call the PROS build CLI command.
  *
  * @param slot The slot number to place the executable in
  */
 
-const runClean = async () => {
+/*const runClean = async () => {
   await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
@@ -38,7 +49,7 @@ const runClean = async () => {
       }
     }
   );
-};
+};*/
 
 export const clean = async () => {
   try {

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -21,36 +21,6 @@ const runClean = async () => {
  * @param slot The slot number to place the executable in
  */
 
-/*const runClean = async () => {
-  await vscode.window.withProgress(
-    {
-      location: vscode.ProgressLocation.Notification,
-      title: "Cleaning Project",
-      cancellable: false,
-    },
-    async (progress, token) => {
-      try {
-        // Command to run to clean project
-        var command = `pros make clean --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
-        console.log(command);
-        const { stdout, stderr } = await promisify(child_process.exec)(
-          command,
-          {
-            timeout: 30000,
-            env: {
-              ...process.env,
-              PATH: getChildProcessPath(),
-            },
-          }
-        );
-        vscode.window.showInformationMessage("Project Cleaned!");
-      } catch (error: any) {
-        throw new Error(parseErrorMessage(error.stdout));
-      }
-    }
-  );
-};*/
-
 export const clean = async () => {
   try {
     await runClean();

--- a/src/commands/command_tools.ts
+++ b/src/commands/command_tools.ts
@@ -54,11 +54,10 @@ export const getCurrentKernelOkapiVersion = async () => {
     args: [
       "c",
       "info-project",
-      "--project",
       "--machine-output",
       ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
     ],
-    message: "Getting current kernel and okapi versions",
+    message: "Fetching Project Info",
     requires_pros_project: true,
     extra_output: true
   };

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,19 +1,35 @@
 import * as vscode from "vscode";
-import * as child_process from "child_process";
-import { promisify } from "util";
-import { parseMakeOutput } from "./cli-parsing";
-import { output } from "../extension";
-import {
-  getChildProcessPath,
-  getChildProcessProsToolchainPath,
-} from "../one-click/path";
+import { Base_Command, Base_Command_Options } from "./base-command";
+
+
+export const run = async () => {
+  const run_command_options: Base_Command_Options = {
+    command: "prosv5",
+    args: [
+      "run",
+      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
+    ],
+    message: "Running Project",
+    requires_pros_project: true
+  }
+
+const run_command: Base_Command = new Base_Command(run_command_options);
+
+try {
+  await run_command.run_command();
+} catch (err: any) {
+  await vscode.window.showErrorMessage(err.message);
+}
+};
+
+
 /**
  * Call the PROS run CLI command.
  *
  * @param slot The slot number to place the executable in
  */
 
-const runRun = async () => {
+/*const runRun = async () => {
   await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
@@ -50,4 +66,4 @@ export const run = async () => {
   } catch (err: any) {
     await vscode.window.showErrorMessage(err.message);
   }
-};
+};*/

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -4,8 +4,9 @@ import { Base_Command, Base_Command_Options } from "./base-command";
 
 export const run = async () => {
   const run_command_options: Base_Command_Options = {
-    command: "prosv5",
+    command: "pros",
     args: [
+      "v5",
       "run",
       ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
     ],
@@ -28,42 +29,3 @@ try {
  *
  * @param slot The slot number to place the executable in
  */
-
-/*const runRun = async () => {
-  await vscode.window.withProgress(
-    {
-      location: vscode.ProgressLocation.Notification,
-      title: "Running Project",
-      cancellable: false,
-    },
-    async (progress, token) => {
-      try {
-        var command = `pros v5 run --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
-        console.log(command);
-        console.log(process.env["PATH"]);
-        const { stdout, stderr } = await promisify(child_process.exec)(
-          command,
-          {
-            env: {
-              ...process.env,
-              PATH: getChildProcessPath(),
-              PROS_TOOLCHAIN: getChildProcessProsToolchainPath(),
-            },
-          }
-        );
-        vscode.window.showInformationMessage("Project Ran!");
-      } catch (error: any) {
-        if (!error.stdout.includes("No v5 ports")) {
-        }
-      }
-    }
-  );
-};
-
-export const run = async () => {
-  try {
-    await runRun();
-  } catch (err: any) {
-    await vscode.window.showErrorMessage(err.message);
-  }
-};*/

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -3,8 +3,9 @@ import { Base_Command, Base_Command_Options } from "./base-command";
 
 export const stop = async () => {
   const stop_command_options: Base_Command_Options = {
-    command: "prosv5",
+    command: "pros",
     args: [
+      "v5",
       "stop",
       ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
     ],

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -1,19 +1,32 @@
 import * as vscode from "vscode";
-import * as child_process from "child_process";
-import { promisify } from "util";
-import { parseMakeOutput } from "./cli-parsing";
-import { output } from "../extension";
-import {
-  getChildProcessPath,
-  getChildProcessProsToolchainPath,
-} from "../one-click/path";
+import { Base_Command, Base_Command_Options } from "./base-command";
+
+export const stop = async () => {
+  const stop_command_options: Base_Command_Options = {
+    command: "prosv5",
+    args: [
+      "stop",
+      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
+    ],
+    message: "Stopping Project",
+    requires_pros_project: true
+  }
+
+const stop_command: Base_Command = new Base_Command(stop_command_options);
+
+try {
+  await stop_command.run_command();
+} catch (err: any) {
+  await vscode.window.showErrorMessage(err.message);
+}
+};
 /**
  * Call the PROS stop CLI command.
  *
  * @param slot The slot number to place the executable in
  */
 
-const runStop = async () => {
+/*const runStop = async () => {
   await vscode.window.withProgress(
     {
       location: vscode.ProgressLocation.Notification,
@@ -60,4 +73,4 @@ export const stop = async () => {
   } catch (err: any) {
     await vscode.window.showErrorMessage(err.message);
   }
-};
+};*/

--- a/src/commands/upgrade-project.ts
+++ b/src/commands/upgrade-project.ts
@@ -11,11 +11,11 @@ const userApproval = async (
   // Ask for user confirmation before upgrading kernal and/or okapi version
   let title;
   if (kernel && okapi) {
-    title = `Upgrade to kernel ${kernel} and Okapilib ${okapi}?`;
-  } else if (kernel) {
-    title = `Upgrade to Okapilib ${okapi}?`;
+    title = `Upgrade to kernel ${kernel} and Okapilib ${okapi}? Warning: There may be breaking changes.`;
+  } else if (okapi) {
+    title = `Upgrade to Okapilib ${okapi}? Warning: There may be breaking changes.`;
   } else {
-    title = `Upgrade to kernel ${kernel}?`;
+    title = `Upgrade to kernel ${kernel}? Warning: There may be breaking changes.`;
   }
   await vscode.window.showQuickPick(
     [{ label: "yes", description: "recommended" }, { label: "no" }],
@@ -28,8 +28,8 @@ const userApproval = async (
 };
 
 export const upgradeProject = async () => {
-  let {target, curKernel, curOkapi} = await getCurrentKernelOkapiVersion();
-  let {newKernel, newOkapi} = await getLatestKernelOkapiVersion(target);
+  //let {target, curKernel, curOkapi} = await getCurrentKernelOkapiVersion();
+  //let {newKernel, newOkapi} = await getLatestKernelOkapiVersion(target);
   const upgrade_project_command_options: Base_Command_Options = {
     command: "pros",
     args: [

--- a/src/commands/upgrade-project.ts
+++ b/src/commands/upgrade-project.ts
@@ -1,119 +1,9 @@
 import * as vscode from "vscode";
-import * as child_process from "child_process";
-import { promisify } from "util";
-import { gt } from "semver";
+import * as path from "path";
 
-import { PREFIX, parseErrorMessage } from "./cli-parsing";
-import { getChildProcessPath } from "../one-click/path";
-/**
- * Queries the PROS project data for the target device.
- *
- * @returns The project's target device and the associated library versions.
- */
+import { Base_Command, Base_Command_Options } from "./base-command";
+import { getCurrentKernelOkapiVersion, getLatestKernelOkapiVersion } from "./command_tools";
 
-const fetchTarget = async (): Promise<{
-  target: string;
-  curKernel: string;
-  curOkapi: string | undefined;
-}> => {
-  // Command to run to fetch the current project that needs to be updated
-  var command = `pros c info-project --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
-  // console.log(command);
-  const { stdout, stderr } = await promisify(child_process.exec)(command, {
-    env: {
-      ...process.env,
-      PATH: getChildProcessPath(),
-    },
-  });
-
-  // Get okapi and kernel version of current project
-  for (let e of stdout.split(/\r?\n/)) {
-    if (e.startsWith(PREFIX)) {
-      let jdata = JSON.parse(e.substr(PREFIX.length));
-      if (jdata.type === "finalize") {
-        const target = jdata.data.project.target;
-        const curKernel = jdata.data.project.templates.find(
-          (t: any) => t.name === "kernel"
-        ).version;
-        const curOkapi = jdata.data.project.templates.find(
-          (t: any) => t.name === "okapilib"
-        ).version;
-        return { target, curKernel, curOkapi };
-      }
-    }
-  }
-  return { target: "", curKernel: "", curOkapi: "" };
-};
-
-/**
- * Queries the server for the latest available library versions.
- *
- * @param target The target device for this project
- * @returns The kernel and okapi (if applicable) library versions
- */
-const fetchServerVersions = async (
-  target: string
-): Promise<{ newKernel: string; newOkapi: string | undefined }> => {
-  // Command to run to fetch latest okapi and kernel versions
-  var command = `pros c q --target ${target} --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
-  // console.log(command);
-  const { stdout, stderr } = await promisify(child_process.exec)(command, {
-    env: {
-      ...process.env,
-      PATH: getChildProcessPath(),
-    },
-  });
-
-  let newKernel = "0.0.0";
-  let newOkapi = "0.0.0";
-
-  // Set current okapi and kernel versions
-  for (let e of stdout.split(/\r?\n/)) {
-    if (e.startsWith(PREFIX)) {
-      let jdata = JSON.parse(e.substr(PREFIX.length));
-      if (jdata.type === "finalize") {
-        for (let ver of jdata.data) {
-          if (ver.name === "kernel" && gt(ver.version, newKernel)) {
-            newKernel = ver.version;
-          } else if (ver.name === "okapilib" && gt(ver.version, newOkapi)) {
-            newOkapi = ver.version;
-          }
-        }
-      }
-    }
-  }
-
-  return { newKernel, newOkapi };
-};
-
-/**
- * Actually performs the upgrade to the latest library versions for the project.
- */
-const runUpgrade = async () => {
-  // Command to run to upgrade project to a newer version
-  var command = `pros c u --project "${vscode.workspace.workspaceFolders?.[0].uri.fsPath}" --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`;
-  console.log(command);
-  const { stdout, stderr } = await promisify(child_process.exec)(command, {
-    encoding: "utf8",
-    maxBuffer: 1024 * 1024 * 50,
-    env: {
-      ...process.env,
-      PATH: getChildProcessPath(),
-    },
-  });
-
-  const errorMessage = parseErrorMessage(stdout);
-  if (errorMessage) {
-    throw new Error(errorMessage);
-  }
-};
-
-/**
- * Confirms with the user that the project should be updated to the specified library versions.
- *
- * @param kernel The new kernel version
- * @param okapi The new Okapilib version
- */
 const userApproval = async (
   kernel: string | undefined,
   okapi: string | undefined
@@ -138,24 +28,39 @@ const userApproval = async (
 };
 
 export const upgradeProject = async () => {
+  let {target, curKernel, curOkapi} = await getCurrentKernelOkapiVersion();
+  let {newKernel, newOkapi} = await getLatestKernelOkapiVersion(target);
+  const upgrade_project_command_options: Base_Command_Options = {
+    command: "pros",
+    args: [
+      "c",
+      "u",
+      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
+    ],
+    message: "Upgrading Project",
+    requires_pros_project: true 
+  }
+
+  const upgrade_project_command: Base_Command = new Base_Command(upgrade_project_command_options);
+
   try {
-    const { target, curKernel, curOkapi } = await fetchTarget();
-    const { newKernel, newOkapi } = await fetchServerVersions(target);
+    const { target, curKernel, curOkapi } = await getCurrentKernelOkapiVersion();
+    const { newKernel, newOkapi } = await getLatestKernelOkapiVersion(target);
     if (curKernel === newKernel && curOkapi === newOkapi) {
       await vscode.window.showInformationMessage("Project is up to date!");
       return;
     }
 
-    // check to see if the update is okay?
     await userApproval(
       newKernel === curKernel ? undefined : newKernel,
       newOkapi === curOkapi ? undefined : newOkapi
     );
 
-    await runUpgrade();
+    await upgrade_project_command.run_command();
 
     await vscode.window.showInformationMessage("Project updated!");
   } catch (err: any) {
     await vscode.window.showErrorMessage(err.message);
   }
+
 };


### PR DESCRIPTION
Code for the following sidebar commands was rewritten to be more concise using the Base Command:
capture,
clean,
run,
stop,
upgrade project.
