### PR TITLE
🐛Don't wait for user to close confirmation message

### DIFF
--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -327,7 +327,7 @@ export async function install(context: vscode.ExtensionContext) {
   //if everything works and cli is up to date, do nothing
   if (cliWorking && toolchainWorking && cliUpToDate && vexcomWorking) {
     // tell the user that everything is up to date
-    await vscode.window.showInformationMessage(
+    vscode.window.showInformationMessage(
       "CLI and Toolchain currently working and up to date."
     );
     console.log("Everything is up to date");


### PR DESCRIPTION
If everything is working, close the installing PROS progress message without waiting for the user to close the information message.