### PR TITLE
🐛 Bugfixes for MacOS (and other stuff)

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -215,7 +215,7 @@ export class BaseCommand {
     liveOutput: string[],
     process: child_process.ChildProcess
   ): Promise<boolean> => {
-    const errorRegex: RegExp = /((Error: )|(ERROR: ))(.+)/;
+    const errorRegex: RegExp = /((Error: )|(ERROR: )|(: error:))(.+)/;
     const yesNoRegex: RegExp = /\[y\/N\]/;
     const promptRegex: RegExp = /\[[A-Za-z0-9|]+\]/;
     // This function will parse the output of the command we ran.

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -3,7 +3,7 @@ import { BaseCommand, BaseCommandOptions } from "./base-command";
 
 const buildCommandOptions: BaseCommandOptions = {
   command: "pros",
-  args: ["build-compile-commands"],
+  args: ["make"],
   message: "Building Project",
   requiresProsProject: true,
 };

--- a/src/commands/command_tools.ts
+++ b/src/commands/command_tools.ts
@@ -130,7 +130,7 @@ export const getLatestKernelOkapiVersion = async (target: string) => {
 export const selectKernelVersion = async (target: string) => {
   // Command to run to fetch all kernel versions
   const kernelVersionCommandOptions: BaseCommandOptions = {
-    command: "prosv5",
+    command: "pros",
     args: [
       "c",
       "ls-templates",

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -522,7 +522,7 @@ export async function cleanup(
       title: "Verifying Installation",
       cancellable: true,
     },
-    async (progress, token) => {
+    async () => {
       try {
         const globalPath = context.globalStorageUri.fsPath;
         await prosLogger.log(

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -534,18 +534,16 @@ export async function cleanup(
             prosLogger.log("OneClick", e, "ERROR");
           }
         );
-        await prosLogger.log("OneClick", `Configuring environment variables`);
-        await configurePaths(context).catch((e) => {
-          prosLogger.log("OneClick", e, "ERROR");
-        });
+
         await prosLogger.log(
           "OneClick",
           `Verifying that CLI and Toolchain are working`
         );
-
         await chmod(globalPath, system);
-
-        //await configurePaths(context);
+        await prosLogger.log("OneClick", `Configuring environment variables`);
+        await configurePaths(context).catch((e) => {
+          prosLogger.log("OneClick", e, "ERROR");
+        });
 
         // Ensure that toolchain and cli are working
         let cliSuccess =

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -240,9 +240,12 @@ export async function install(context: vscode.ExtensionContext) {
   var cliName = `pros-cli-${system}.zip`;
   var vexcomName = `vex-vexcom-${system}.zip`;
   // Title of prompt depending on user's installed CLI
+  let [cliExecPath] = getIntegratedTerminalPaths(context);
+  const addQuotes =
+    getOperatingSystem() === "macos" && !os.cpus()[0].model.includes("Apple M");
   var title = await getInstallPromptTitle(
     path.join(
-      `"${path.join(globalPath, "install", `pros-cli-${system}`)}"`,
+      `${addQuotes ? `"` : ""}${cliExecPath}${addQuotes ? `"` : ""}`,
       "pros"
     ),
     releaseVersionNumber ?? 0

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import * as path from "path";
 
 /*!
  * @brief This function returns the current working directory (vscode.Uri) and if it is a pros project (boolean)
@@ -14,19 +15,22 @@ export const getCwdIsPros = async (): Promise<vscode.Uri | null> => {
   //output the 0th workspace folder
 
   let active = vscode.window.activeTextEditor?.document.uri ?? undefined;
-  let activeDir = undefined;
+  let activeDir = null;
 
   const filenameSearch = "project.pros";
+  let prosProjects = await vscode.workspace.findFiles(filenameSearch);
 
-  if (active !== undefined) {
+  if (prosProjects.length === 1) {
+    console.log(`pros project: ${prosProjects[0].path}`);
+    activeDir = vscode.Uri.file(path.dirname(prosProjects[0].fsPath));
+  } else if (active !== undefined) {
     console.log(`active: ${active}`);
-    activeDir = vscode.workspace.getWorkspaceFolder(active)?.uri;
-    console.log(`workspace folder: ${activeDir}`);
-  } else if (
-    vscode.workspace.workspaceFolders !== undefined &&
-    vscode.workspace.workspaceFolders !== null
-  ) {
-    activeDir = vscode.workspace.workspaceFolders[0].uri;
+    let potentialDir = vscode.workspace.getWorkspaceFolder(active);
+    prosProjects.forEach((path) => {
+      if (potentialDir === vscode.workspace.getWorkspaceFolder(path)) {
+        activeDir = potentialDir?.uri;
+      }
+    });
   }
 
   if (activeDir === undefined || activeDir === null) {


### PR DESCRIPTION
- Add checking for build errors in BaseCommand
- Change selectKernelVersion to use `pros` instead of `prosv5`
- Fix issue on Mac where CLI is shown as not up to date (#113)
- Make getCwdIsPros to be less reliant on activeTextEditor