### PR TITLE
🐛 Change Select Directory to Select Folder

### DIFF
--- a/src/commands/command_tools.ts
+++ b/src/commands/command_tools.ts
@@ -8,9 +8,9 @@ export const selectDirectory = async (prompt: string) => {
   const directoryOptions: vscode.OpenDialogOptions = {
     canSelectMany: false,
     title: prompt ?? "Select a directory",
-    openLabel: "Select file",
+    openLabel: "Select Folder",
     canSelectFolders: true,
-    canSelectFiles: true,
+    canSelectFiles: false,
   };
   const uri: string | undefined = await vscode.window
     .showOpenDialog(directoryOptions)


### PR DESCRIPTION
Change prompt to Select Folder instead of Select File and prevent single file selection for directory selection.