### PR TITLE
🐛 Check for Error message without colon

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -11,11 +11,11 @@ import { getCwdIsPros } from "../workspace";
 
     I realize I missed something quite important in the presentation. It's the idea of synchronous v.s. asynchronous functions.
 
-    In short, a synchronous function is one that blocks the execution of the program until it completes. 
+    In short, a synchronous function is one that blocks the execution of the program until it completes.
     An asynchronous function is one that does not block the execution of the program until it completes.
 
     The way this works is that when either function is called, it waits until something is returned to it.
-    However, in the case of an asynchronous function, it will return a promise. 
+    However, in the case of an asynchronous function, it will return a promise.
     This promise is a placeholder for the value that will be returned later.
 
     This is how javascript enables having multiple things happen at once, since by design, javascript is single-threaded.
@@ -215,7 +215,7 @@ export class BaseCommand {
     liveOutput: string[],
     process: child_process.ChildProcess
   ): Promise<boolean> => {
-    const errorRegex: RegExp = /((Error: )|(ERROR: )|(: error:))(.+)/;
+    const errorRegex: RegExp = /((Error: )|(ERROR )|(ERROR: )|(: error:))(.+)/;
     const yesNoRegex: RegExp = /\[y\/N\]/;
     const promptRegex: RegExp = /\[[A-Za-z0-9|]+\]/;
     // This function will parse the output of the command we ran.


### PR DESCRIPTION
Now shows an ERROR message on Run, Stop, and Capture commands when no brain is plugged in. This does however now throw two errors for Upload and other commands that print two errors to the terminal. Needs to be some sort of better solution for this. 
<img width="480" alt="Screenshot_2022-12-12_at_5 26 40_PM" src="https://user-images.githubusercontent.com/22580992/207100198-33e18b4a-2a86-4c12-bd0c-18b338760248.png">
