### PR TITLE
🐛 Half Baked Multi Port Select Fix

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -218,7 +218,6 @@ export class BaseCommand {
     const errorRegex: RegExp = /((Error: )|(ERROR )|(ERROR: )|(: error:))(.+)/;
     const yesNoRegex: RegExp = /\[y\/N\]/;
     const promptRegex: RegExp = /\[([^\]]+)\]/;
-
     // This function will parse the output of the command we ran.
     // Normally, we use the --machine-output flag to get the output in a json format.
     // This makes it easier to parse the output, as everything is categorized into different levels, such as Warning or error.

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -217,7 +217,8 @@ export class BaseCommand {
   ): Promise<boolean> => {
     const errorRegex: RegExp = /((Error: )|(ERROR )|(ERROR: )|(: error:))(.+)/;
     const yesNoRegex: RegExp = /\[y\/N\]/;
-    const promptRegex: RegExp = /\[[A-Za-z0-9|]+\]/;
+    const promptRegex: RegExp = /\[([^\]]+)\]/;
+
     // This function will parse the output of the command we ran.
     // Normally, we use the --machine-output flag to get the output in a json format.
     // This makes it easier to parse the output, as everything is categorized into different levels, such as Warning or error.
@@ -256,7 +257,7 @@ export class BaseCommand {
         vscode.window
           .showWarningMessage(
             line,
-            ...prompt[0].replace(/[\[\]]/, "").split(/\|/)
+            ...prompt[1].replace(/[\[\]]/, "").split(/\|/)
           )
           .then((response) => {
             if (response) {


### PR DESCRIPTION
There are issues with the CLI port selection, mainly getting multiple ports found when there is only one. And the CLI error will only print one of the possible phantom ports on the first print. This at least allows some sort of interactive solution that should work 50% of the time?