### PR TITLE
🐛 Change IntelliSense C and C++ Standards

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -587,7 +587,8 @@ const modifyJson = async (dirpath: vscode.Uri, json: any, os: string) => {
     dirpath.fsPath,
     "compile_commands.json"
   );
-  json.configurations[0].cppStandard = "gnu++17";
+  json.configurations[0].cStandard = "gnu11";
+  json.configurations[0].cppStandard = "gnu++20";
   json.configurations[0].intelliSenseMode = "gcc-arm";
   if (os === "macos") {
     json.configurations[0].macFrameworkPath = ["/System/Library/Frameworks"];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -587,6 +587,7 @@ const modifyJson = async (dirpath: vscode.Uri, json: any, os: string) => {
     dirpath.fsPath,
     "compile_commands.json"
   );
+  json.configurations[0].cppStandard = "gnu++17";
   json.configurations[0].intelliSenseMode = "gcc-arm";
   if (os === "macos") {
     json.configurations[0].macFrameworkPath = ["/System/Library/Frameworks"];


### PR DESCRIPTION
Changes the C++ standard in `c_cpp_properties.json` to "gnu++17". This adds some features that are not in standard C++17, such as math constants. We may also want to change the C standard to "gnu17".