### PR TITLE
🐛 New Show Terminal Keybind

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,9 +195,9 @@
     ],
     "keybindings": [
       {
-        "key": "ctrl+shift+i",
+        "key": "ctrl+shift+o",
         "command": "pros.showterminal",
-        "mac": "cmd+shift+i"
+        "mac": "cmd+shift+o"
       },
       {
         "key": "ctrl+shift+b",


### PR DESCRIPTION
Changed the show terminal keybind from Ctrl+Shift+I to Ctrl+Shift+O to avoid Linux keybind conflicts.