### PR TITLE
🐛 Better Toolchain Verification

### DIFF
--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -709,7 +709,12 @@ async function verifyToolchain() {
 
   await prosLogger.log("OneClick", `Using toolchain path ${toolchainPath}`);
 
-  let command = "arm-none-eabi-g++ --version";
+  let command = `"${path.join(
+    toolchainPath,
+    "bin",
+    "arm-none-eabi-g++"
+  )}" --version`;
+  console.log(command);
   await prosLogger.log(
     "OneClick",
     `Verifying TOOLCHAIN with command ${command}`

--- a/src/one-click/installed.ts
+++ b/src/one-click/installed.ts
@@ -20,7 +20,9 @@ export async function getCurrentReleaseVersion(url: string) {
   return vString;
 }
 
-export async function getCurrentVersion(oneClickPath: string) {
+export async function getCurrentVersion(
+  oneClickPath: string
+): Promise<[number, boolean]> {
   try {
     console.log(oneClickPath);
     prosLogger.log(


### PR DESCRIPTION
currently, if the user had a different toolchain that had arm-none-eabi-g++ but not through the PROS Toolchain, they may encounter problems where the build process is not quite right but verification passed the toolchain installation anyways. This requires the executable to exist under the PROS_TOOLCHAIN directory. Tested on windows, needs mac and/or linux testing.