### PR TITLE
🐛 Fix Experimental Features

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,7 @@ const setupCommandBlocker = async (
         .get("Beta: Enable Experimental Features")
     ) {
       vscode.window.showErrorMessage(
-        "This feature is currently in beta. To enable it, set the 'pros.betaFeatures' setting in your workspace settings to true."
+        "This feature is currently in beta. To enable it, set the 'pros.Beta: Enable Experimental Feature' setting in your workspace settings to true."
       );
       return;
     }
@@ -178,9 +178,9 @@ export async function activate(context: vscode.ExtensionContext) {
   setupCommandBlocker("pros.deleteLogs", prosLogger.deleteLogs);
   setupCommandBlocker("pros.openLog", prosLogger.openLog);
 
-  setupCommandBlocker("pros.installVision", installVision, context);
-  setupCommandBlocker("pros.uninstallVision", uninstallVision, context);
-  setupCommandBlocker("pros.runVision", runVision, context);
+  setupCommandBlocker("pros.installVision", installVision, context, true);
+  setupCommandBlocker("pros.uninstallVision", uninstallVision, context, true);
+  setupCommandBlocker("pros.runVision", runVision, context, true);
 
   setupCommandBlocker(
     "pros.selectProject",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,9 @@ const setupCommandBlocker = async (
   vscode.commands.registerCommand(cmd, async () => {
     if (
       betaFeature &&
-      !vscode.workspace.getConfiguration("pros").get("betaFeatures")
+      !vscode.workspace
+        .getConfiguration("pros")
+        .get("Beta: Enable Experimental Features")
     ) {
       vscode.window.showErrorMessage(
         "This feature is currently in beta. To enable it, set the 'pros.betaFeatures' setting in your workspace settings to true."
@@ -298,7 +300,12 @@ export async function activate(context: vscode.ExtensionContext) {
     new TreeDataProvider()
   );
 
-  const brainViewProvider = new BrainViewProvider(context.extensionUri);
+  const brainViewProvider = new BrainViewProvider(
+    context.extensionUri,
+    !vscode.workspace
+      .getConfiguration("pros")
+      .get("Beta: Enable Experimental Features")
+  );
   vscode.window.registerWebviewViewProvider(
     BrainViewProvider.viewType,
     brainViewProvider

--- a/src/views/brain-view.ts
+++ b/src/views/brain-view.ts
@@ -14,7 +14,12 @@ export class BrainViewProvider implements vscode.WebviewViewProvider {
 
   private _view?: vscode.WebviewView;
 
-  constructor(private readonly _extensionUri: vscode.Uri) {}
+  constructor(
+    private readonly _extensionUri: vscode.Uri,
+    private readonly _disabled: boolean = false
+  ) {
+    console.log("BrainViewProvider constructor: " + _disabled);
+  }
 
   public resolveWebviewView(
     webviewView: vscode.WebviewView,
@@ -71,6 +76,22 @@ export class BrainViewProvider implements vscode.WebviewViewProvider {
   }
 
   private _getHtmlForWebview(webview: vscode.Webview): string {
+    if (this._disabled) {
+      return `<!DOCTYPE html>
+      <html lang="en">
+      <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Brain View</title>
+      </head>
+      <body>
+          <h1>This is an Expiremental Feature</h1>
+          <p>It is currently disabled. To enable it, enable "Pros: Beta: Enable Experimental Features" in your VSCode settings and restart VSCode.</p>
+      </body>
+      </html>
+      `;
+    }
+
     // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
     const scriptUri = webview.asWebviewUri(
       vscode.Uri.joinPath(this._extensionUri, "media", "brainView.js")


### PR DESCRIPTION
Fixes type on getting the experimental feature workspace setting.
Adds a different HTML for brainview if the user does not have experimental features enabled.
Forces Vision Utility to use related features.