### PR TITLE
🐛 Suspend Device Search When Updating CLI

### DIFF
--- a/src/device.ts
+++ b/src/device.ts
@@ -99,6 +99,7 @@ export type PROSDeviceInfo = {
 
 var currentPort = "";
 var portList: PROSDeviceInfo[] = [];
+var suspended = false;
 
 export const getV5ComPorts = (): PROSDeviceInfo[] => {
   return portList;
@@ -160,6 +161,9 @@ export const getV5DeviceInfo = async (port: string): Promise<V5DeviceInfo> => {
 };
 
 const resolvePort = async (status: StatusBarItem): Promise<void> => {
+  if (suspended) {
+    return;
+  }
   let v5Ports = await getV5ComPortsInternal();
 
   let showNotifications =
@@ -218,6 +222,14 @@ const formatDescription = (description: string): string => {
 
 export const setPort = (port: string): void => {
   currentPort = port;
+};
+
+export const suspend = (): void => {
+  suspended = true;
+};
+
+export const unsuspend = (): void => {
+  suspended = false;
 };
 
 export const getCurrentPort = (): string => {

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -19,6 +19,7 @@ import {
 } from "./path";
 import { prosLogger } from "../extension";
 import { BackgroundProgress } from "../logger";
+import * as device from "../device";
 //TOOLCHAIN and CLI_EXEC_PATH are exported and used for running commands.
 export var TOOLCHAIN: string;
 export var CLI_EXEC_PATH: string;
@@ -367,7 +368,14 @@ export async function install(context: vscode.ExtensionContext) {
         "OneClick",
         "Toolchain is not working. Installing just the toolchain"
       );
-      promises = [downloadextract(context, downloadToolchain, toolchainName)];
+      promises = [
+        downloadextract(
+          context,
+          downloadToolchain,
+          toolchainName,
+          "PROS Toolchain"
+        ),
+      ];
     } else {
       await prosLogger.log(
         "OneClick",
@@ -393,7 +401,8 @@ export async function install(context: vscode.ExtensionContext) {
     console.log("sent : " + prompttitle);
     preparingInstall.stop();
     if (labelResponse === option1) {
-      targetedPortion = path.join("install", `pros-cli-${system}}`);
+      device.suspend();
+      targetedPortion = path.join("install", `pros-cli-${system}`);
       let deleteDir = path.join(
         context.globalStorageUri.fsPath,
         targetedPortion
@@ -442,6 +451,7 @@ export async function install(context: vscode.ExtensionContext) {
     console.log("sent : " + prompttitle);
     preparingInstall.stop();
     if (labelResponse === "Install Now!") {
+      device.suspend();
       await prosLogger.log("OneClick", "Removing Old CLI and Toolchain");
       console.log("removing old cli and toolchain");
       await removeDirAsync(
@@ -495,6 +505,7 @@ export async function install(context: vscode.ExtensionContext) {
   console.log("Cleanup and Verification");
   await prosLogger.log("OneClick", "Cleaning up after installation");
   await vscode.commands.executeCommand("pros.verify");
+  device.unsuspend();
 
   // Do we want to auto disable install on startup? This will remove the auto update portion of the extension right?
   /*


### PR DESCRIPTION
The device search for checking when a v5 device connects/disconnects calls `pros lsusb` every 500 milliseconds, which poses a problem when trying to update the CLI. This PR fixes this issue by suspending the device search while updating the CLI and unsuspending it afterwards.