### PR TITLE
🐛 Fix toolchain verification on Intel Mac

### DIFF
--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -659,18 +659,18 @@ export async function configurePaths(
   process.env.PATH = `${process.env.PATH}`; // bypass compile errors
   await prosLogger.log("OneClick", process.env.PATH ?? "no PATH", "INFO");
   process.env.PATH =
-    `${addQuotes ? `"` : ""}` +
     `${cliExecPath}${PATH_SEP}` +
     `${path.join(toolchainPath, "bin")}${PATH_SEP}` +
     `${vexcomPath}${PATH_SEP}` +
-    `${process.env.PATH.replace(/\"/g, "")}` +
-    `${addQuotes ? `"` : ""}`;
+    `${process.env.PATH.replace(/\"/g, "")}`;
   await prosLogger.log("OneClick", process.env.PATH ?? "no PATH", "INFO");
   // Make PROS_TOOCLHAIN variable
   await prosLogger.log("OneClick", "Setting PROS_TOOLCHAIN");
-  process.env.PROS_TOOLCHAIN = `${addQuotes ? `"` : ""}${TOOLCHAIN}${
-    addQuotes ? `"` : ""
-  }`;
+  if (!process.env["PROS_TOOLCHAIN"]?.includes(TOOLCHAIN)) {
+    process.env.PROS_TOOLCHAIN = `${addQuotes ? `"` : ""}${TOOLCHAIN}${
+      addQuotes ? `"` : ""
+    }`;
+  }
 
   process.env.LC_ALL = "en_US.utf-8";
   if (repeat) {
@@ -713,11 +713,11 @@ async function verifyToolchain() {
 
   await prosLogger.log("OneClick", `Using toolchain path ${toolchainPath}`);
 
-  let command = `"${path.join(
+  let command = `${path.join(
     toolchainPath,
     "bin",
     "arm-none-eabi-g++"
-  )}" --version`;
+  )} --version`;
   console.log(command);
   await prosLogger.log(
     "OneClick",

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -666,11 +666,7 @@ export async function configurePaths(
   await prosLogger.log("OneClick", process.env.PATH ?? "no PATH", "INFO");
   // Make PROS_TOOCLHAIN variable
   await prosLogger.log("OneClick", "Setting PROS_TOOLCHAIN");
-  if (!process.env["PROS_TOOLCHAIN"]?.includes(TOOLCHAIN)) {
-    process.env.PROS_TOOLCHAIN = `${addQuotes ? `"` : ""}${TOOLCHAIN}${
-      addQuotes ? `"` : ""
-    }`;
-  }
+  process.env.PROS_TOOLCHAIN = TOOLCHAIN;
 
   process.env.LC_ALL = "en_US.utf-8";
   if (repeat) {
@@ -713,11 +709,11 @@ async function verifyToolchain() {
 
   await prosLogger.log("OneClick", `Using toolchain path ${toolchainPath}`);
 
-  let command = `${path.join(
+  let command = `"${path.join(
     toolchainPath,
     "bin",
     "arm-none-eabi-g++"
-  )} --version`;
+  )}" --version`;
   console.log(command);
   await prosLogger.log(
     "OneClick",


### PR DESCRIPTION
For Intel Macs, we need quotes around the toolchain path for it to work properly. However, the previous code mistakenly added quotes around the path multiple times. This PR fixes that.