### PR TITLE
Change Prettier Version on GitHub Action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,7 @@ jobs:
         uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --check **/*.{js,ts,jsx,tsx,md,css,html}
+          prettier_version: 2.8.8
   eslint_check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Prettier GitHub is causing weird errors, probably due to being on v3 while we're still on v2.