### PR TITLE
:bug: Change when project.pros editor is enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,7 +324,7 @@
         "displayName": "PROS Project",
         "selector": [
           {
-            "filenamePattern": "*.pros"
+            "filenamePattern": "project.pros"
           }
         ]
       }


### PR DESCRIPTION
Currently it is activated for all files that end with .pros. This PR changes that to only files called project.pros