### PR TITLE
:sparkles: Make Project Selection Not Disappear 

### DIFF
--- a/src/workspace_utils.ts
+++ b/src/workspace_utils.ts
@@ -245,15 +245,23 @@ export async function chooseProject() {
   const targetOptions: vscode.QuickPickOptions = {
     placeHolder: array[0].name,
     title: "Select the PROS project to work on",
+    ignoreFocusOut: true,
   };
   var folderNames: Array<vscode.QuickPickItem> = [];
   for (const f of array) {
     folderNames.push({ label: f[0], description: "" });
   }
+  folderNames.push({
+    label: "PROS: Cancel Selection",
+    description: "Do not open a project",
+  });
   // Display the options to users
   const target = await vscode.window.showQuickPick(folderNames, targetOptions);
   if (target === undefined) {
     throw new Error();
+  }
+  if (target.label === "PROS: Cancel Selection") {
+    return;
   }
   //This will open the folder the user selects
   await vscode.commands.executeCommand(

--- a/src/workspace_utils.ts
+++ b/src/workspace_utils.ts
@@ -253,7 +253,7 @@ export async function chooseProject() {
   }
   folderNames.push({
     label: "PROS: Cancel Selection",
-    description: "Do not open a project",
+    description: "Do not open a PROS project",
   });
   // Display the options to users
   const target = await vscode.window.showQuickPick(folderNames, targetOptions);


### PR DESCRIPTION
Automatic project selection would disappear if the user clicked somewhere by mistake, which has led to a lot of problems where users are working in a folder that contains a PROS project, as opposed to working in the PROS project. This should help fix that problem.