### PR TITLE
🐛Remove Kernel Version Requirement for Integrated Docs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -160,9 +160,6 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   });
 
-  const projectVersions = await getCurrentKernelOkapiVersion();
-  const projectKernelVersion = projectVersions?.curKernel;
-
   startPortMonitoring(
     vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0)
   );
@@ -261,14 +258,8 @@ export async function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  // if we are using beta and it is a pros 4 project
-
-  console.log("current kernel version: " + projectKernelVersion ?? "undefined");
-  if (
-    usingbeta &&
-    projectKernelVersion !== undefined &&
-    projectKernelVersion.startsWith("4")
-  ) {
+  // if we are using beta
+  if (usingbeta) {
     populateDocsJSON();
     vscode.languages.registerHoverProvider("*", {
       provideHover(document, position, token) {


### PR DESCRIPTION
Currently, we require 2 things to use the integrated docs feature:
1) The user is currently in a project
2) The user is on a PROS 4 project

I personally don't think requirement 2 should be a thing, much less requirement 1. If users wish to view the documentation while not in a PROS project they should have the ability. Additionally, the APIs between PROS 3 and PROS 4 are almost entirely the same, so the PROS 4 docs should be mostly fine for PROS 3 users. Since this feature is still in experimental mode, something the user has to enable, I will also assume that the people who will have access to and use this may already be on PROS 4.