### PR TITLE
✨ Add beta flag support to create projects

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -35,6 +35,7 @@ export type BaseCommandOptions = {
   requiresProsProject: boolean;
   extraOutput?: boolean;
   successMessage?: string;
+  optionalArgs?: (string | undefined)[];
 };
 export class BaseCommand {
   command: string;
@@ -74,6 +75,12 @@ export class BaseCommand {
 
     this.command = options.command;
     this.args = options.args;
+    // for each element in optionalArgs, if the element is not undefined, add it to args
+    for (let arg of options.optionalArgs ?? []) {
+      if (arg !== undefined) {
+        this.args.push(arg);
+      }
+    }
     this.args.push(...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []));
     this.message = options.message;
     this.cwd = process.cwd();

--- a/src/commands/capture.ts
+++ b/src/commands/capture.ts
@@ -25,12 +25,7 @@ export const capture = async () => {
 
   const captureCommandOptions: BaseCommandOptions = {
     command: "pros",
-    args: [
-      "v5",
-      "capture",
-      `${path.join(dir, file)}`,
-      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
-    ],
+    args: ["v5", "capture", `${path.join(dir, file)}`],
     message: "Capturing Screenshot",
     requiresProsProject: true,
   };

--- a/src/commands/command_tools.ts
+++ b/src/commands/command_tools.ts
@@ -3,6 +3,7 @@ import { gt } from "semver";
 
 import { PREFIX } from "./cli-parsing";
 import { BaseCommand, BaseCommandOptions } from "./base-command";
+import { betaFeaturesEnabled } from "../extension";
 
 export const selectDirectory = async (prompt: string) => {
   const directoryOptions: vscode.OpenDialogOptions = {
@@ -71,12 +72,7 @@ export const selectTarget = async () => {
 export const getCurrentKernelOkapiVersion = async () => {
   const kernelOkapiVersionCommandOptions: BaseCommandOptions = {
     command: "pros",
-    args: [
-      "c",
-      "info-project",
-      "--machine-output",
-      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
-    ],
+    args: ["c", "info-project", "--machine-output"],
     message: "Fetching Project Info",
     requiresProsProject: true,
     extraOutput: true,
@@ -108,14 +104,7 @@ export const getCurrentKernelOkapiVersion = async () => {
 export const getLatestKernelOkapiVersion = async (target: string) => {
   const latestKernelOkapiVersionCommandOptions: BaseCommandOptions = {
     command: "pros",
-    args: [
-      "c",
-      "q",
-      "--target",
-      target,
-      "--machine-output",
-      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
-    ],
+    args: ["c", "q", "--target", target, "--machine-output"],
     message: "Getting latest kernel and okapi versions",
     requiresProsProject: true,
     extraOutput: true,
@@ -151,14 +140,8 @@ export const selectKernelVersion = async (target: string) => {
   // Command to run to fetch all kernel versions
   const kernelVersionCommandOptions: BaseCommandOptions = {
     command: "pros",
-    args: [
-      "c",
-      "ls-templates",
-      "--target",
-      target,
-      "--machine-output",
-      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
-    ],
+    args: ["c", "ls-templates", "--target", target, "--machine-output"],
+    optionalArgs: [betaFeaturesEnabled ? "--beta" : undefined],
     message: "Fetching kernel versions",
     requiresProsProject: false,
     extraOutput: true,

--- a/src/commands/create-project.ts
+++ b/src/commands/create-project.ts
@@ -9,6 +9,8 @@ import {
   selectKernelVersion,
 } from "./command_tools";
 
+import { betaFeaturesEnabled } from "../extension";
+
 export const createNewProject = async () => {
   let dir = await selectDirectory(
     "Select a directory to create the project in"
@@ -47,8 +49,8 @@ export const createNewProject = async () => {
       `${target}`,
       `${kernel}`,
       "--build-cache",
-      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
     ],
+    optionalArgs: [betaFeaturesEnabled ? "--beta" : undefined],
     message: "Creating Project",
     requiresProsProject: false,
     successMessage: "Project Created Successfully",

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -6,12 +6,7 @@ export const run = async () => {
   const slot = await findSlotFromProjectPros();
   const runCommandOptions: BaseCommandOptions = {
     command: "pros",
-    args: [
-      "v5",
-      "run",
-      slot.toString(),
-      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
-    ],
+    args: ["v5", "run", slot.toString()],
     message: "Running Project",
     requiresProsProject: true,
     successMessage: "hidden", // I don't think we need an explicit success message here, they'll see if it's running or not on the brain

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -4,11 +4,7 @@ import { BaseCommand, BaseCommandOptions } from "./base-command";
 export const stop = async () => {
   const stopCommandOptions: BaseCommandOptions = {
     command: "pros",
-    args: [
-      "v5",
-      "stop",
-      ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []),
-    ],
+    args: ["v5", "stop"],
     message: "Stopping Project",
     requiresProsProject: true,
     successMessage: "Project Stopped Successfully",

--- a/src/commands/upgrade-project.ts
+++ b/src/commands/upgrade-project.ts
@@ -39,7 +39,7 @@ export const upgradeProject = async () => {
   //let {newKernel, newOkapi} = await getLatestKernelOkapiVersion(target);
   const upgradeProjectCommandOptions: BaseCommandOptions = {
     command: "pros",
-    args: ["c", "u", ...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? [])],
+    args: ["c", "u"],
     message: "Upgrading Project",
     requiresProsProject: true,
     successMessage: "Project Upgraded Successfully",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,6 +135,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   prosLogger = new Logger(context, "PROS_Extension_log", true, "Use Logger");
 
+  // Check if beta features are enabled
   betaFeaturesEnabled =
     vscode.workspace
       .getConfiguration("pros")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,6 +114,7 @@ export var mainPage: string =
   "https://purduesigbots.github.io/pros-doxygen-docs/api.html#autotoc_md1";
 export var currentUrl: string = "https://";
 
+export var betaFeaturesEnabled: boolean = false;
 /// Get a reference to the "PROS Terminal" VSCode terminal used for running
 /// commands.
 
@@ -134,7 +135,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   prosLogger = new Logger(context, "PROS_Extension_log", true, "Use Logger");
 
-  const usingbeta =
+  betaFeaturesEnabled =
     vscode.workspace
       .getConfiguration("pros")
       .get<boolean>("Beta: Enable Experimental Features") ?? false;
@@ -259,7 +260,7 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   // if we are using beta
-  if (usingbeta) {
+  if (betaFeaturesEnabled) {
     populateDocsJSON();
     vscode.languages.registerHoverProvider("*", {
       provideHover(document, position, token) {


### PR DESCRIPTION
Users with the PROS: Enable Experimental Features setting enabled will have the `Create Project` sidebar button use the `--beta` flag when querying templates and creating the project. Needs a decent amount of integration testing, I only did some quick testing on windows to see if it was functional.