### PR TITLE
:bug: Pre-Release Fixes

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -254,6 +254,9 @@ export class BaseCommand {
       var prompt = promptRegex.exec(line);
       if (error) {
         errorMsg = line;
+        if (errorMsg.length > 103) {
+          errorMsg = errorMsg.substring(0, 100) + "...";
+        }
         return true;
       } else if (yesNo) {
         // handle confirm dialogs

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -81,7 +81,9 @@ export class BaseCommand {
         this.args.push(arg);
       }
     }
-    this.args.push(...(process.env["PROS_VSCODE_FLAGS"]?.split(" ") ?? []));
+    if (this.command === "pros" && process.env.PROS_VSCODE_FLAGS) {
+      this.args.push(...`${process.env.PROS_VSCODE_FLAGS}`.split(" "));
+    }
     this.message = options.message;
     this.cwd = process.cwd();
     this.requiresProsProject = options.requiresProsProject;

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -230,7 +230,7 @@ export class BaseCommand {
   ): Promise<boolean> => {
     const errorRegex: RegExp = /((Error: )|(ERROR )|(ERROR: )|(: error:))(.+)/;
     const yesNoRegex: RegExp = /\[y\/N\]/;
-    const promptRegex: RegExp = /\[[A-Za-z0-9|]+\]/;
+    const promptRegex: RegExp = /\[[\s\S]+\]/;
     // This function will parse the output of the command we ran.
     // Normally, we use the --machine-output flag to get the output in a json format.
     // This makes it easier to parse the output, as everything is categorized into different levels, such as Warning or error.

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,16 +1,15 @@
 import * as vscode from "vscode";
 import { BaseCommand, BaseCommandOptions } from "./base-command";
 
-const buildCommandOptions: BaseCommandOptions = {
-  command: "pros",
-  args: ["make"],
-  message: "Building Project",
-  requiresProsProject: true,
-  successMessage: "Project Built Successfully",
-};
-const buildCommand: BaseCommand = new BaseCommand(buildCommandOptions);
-
 export const build = async () => {
+  const buildCommandOptions: BaseCommandOptions = {
+    command: "pros",
+    args: ["make"],
+    message: "Building Project",
+    requiresProsProject: true,
+    successMessage: "Project Built Successfully",
+  };
+  const buildCommand: BaseCommand = new BaseCommand(buildCommandOptions);
   try {
     await buildCommand.runCommand();
   } catch (err: any) {

--- a/src/commands/buildUpload.ts
+++ b/src/commands/buildUpload.ts
@@ -1,7 +1,20 @@
-import { build } from "./build";
+import { BaseCommand, BaseCommandOptions } from "./base-command";
+import { window } from "vscode";
 import { upload } from "./upload";
 
 export const buildUpload = async () => {
-  await build();
+  const buildCommandOptions: BaseCommandOptions = {
+    command: "pros",
+    args: ["make"],
+    message: "Building Project",
+    requiresProsProject: true,
+    successMessage: "hidden",
+  };
+  const buildCommand: BaseCommand = new BaseCommand(buildCommandOptions);
+  try {
+    await buildCommand.runCommand();
+  } catch (err: any) {
+    await window.showErrorMessage(err.message);
+  }
   await upload();
 };

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -4,7 +4,7 @@ import { BaseCommand } from "./base-command";
 const runClean = async () => {
   const cleanCommand = new BaseCommand({
     command: "pros",
-    args: ["make", "clean", ...`${process.env.PROS_VSCODE_FLAGS}`.split(" ")],
+    args: ["make", "clean"],
     message: "Cleaning Project",
     requiresProsProject: true,
     successMessage: "Project Cleaned Successfully",

--- a/src/commands/command_tools.ts
+++ b/src/commands/command_tools.ts
@@ -74,6 +74,7 @@ export const getCurrentKernelOkapiVersion = async () => {
     command: "pros",
     args: ["c", "info-project", "--machine-output"],
     message: "Fetching Project Info",
+    successMessage: "hidden",
     requiresProsProject: true,
     extraOutput: true,
   };
@@ -106,6 +107,7 @@ export const getLatestKernelOkapiVersion = async (target: string) => {
     command: "pros",
     args: ["c", "ls-templates", "--target", target, "--machine-output"],
     message: "Getting latest kernel and okapi versions",
+    successMessage: "hidden",
     requiresProsProject: true,
     extraOutput: true,
   };

--- a/src/commands/command_tools.ts
+++ b/src/commands/command_tools.ts
@@ -104,7 +104,7 @@ export const getCurrentKernelOkapiVersion = async () => {
 export const getLatestKernelOkapiVersion = async (target: string) => {
   const latestKernelOkapiVersionCommandOptions: BaseCommandOptions = {
     command: "pros",
-    args: ["c", "q", "--target", target, "--machine-output"],
+    args: ["c", "ls-templates", "--target", target, "--machine-output"],
     message: "Getting latest kernel and okapi versions",
     requiresProsProject: true,
     extraOutput: true,

--- a/src/commands/upload-command.ts
+++ b/src/commands/upload-command.ts
@@ -32,6 +32,9 @@ export class UploadCommand extends BaseCommand {
           output.appendLine(jdata.simpleMessage);
           if (jdata.level === "ERROR") {
             errorMsg = jdata.simpleMessage;
+            if (errorMsg.length > 103) {
+              errorMsg = errorMsg.substring(0, 100) + "...";
+            }
             return true;
           }
         } else if (jdata.type === "input/interactive" && jdata.can_confirm) {

--- a/src/commands/upload-command.ts
+++ b/src/commands/upload-command.ts
@@ -14,9 +14,6 @@ export class UploadCommand extends BaseCommand {
       requiresProsProject: true,
       successMessage: "Project Uploaded Successfully",
     });
-    if (process.env.PROS_VSCODE_FLAGS) {
-      this.args.push(...`${process.env.PROS_VSCODE_FLAGS}`.split(" "));
-    }
   }
 
   parseOutput = async (

--- a/src/commands/upload-command.ts
+++ b/src/commands/upload-command.ts
@@ -20,7 +20,7 @@ export class UploadCommand extends BaseCommand {
     liveOutput: string[],
     process: ChildProcess
   ): Promise<boolean> => {
-    const promptRegex: RegExp = /\[[A-Za-z0-9|]+\]/;
+    const promptRegex: RegExp = /\[[\s\S]+\]/g;
 
     var errorMsg: string = "";
     var hasError = liveOutput.some((line) => {
@@ -60,11 +60,12 @@ export class UploadCommand extends BaseCommand {
           this.lastProgress = progress;
         }
       } else if (line.startsWith("Multiple") && prompt) {
+        let ports = prompt[0].replace(/[\[\]]/g, "").split(/\|/);
         // only time prompt is used is when there are mutltiple ports
         window
           .showWarningMessage(
             line,
-            ...prompt[0].replace(/[\[\]]/g, "").split(/\|/)
+            ...ports
           )
           .then((response) => {
             if (response) {

--- a/src/commands/upload-command.ts
+++ b/src/commands/upload-command.ts
@@ -62,18 +62,13 @@ export class UploadCommand extends BaseCommand {
       } else if (line.startsWith("Multiple") && prompt) {
         let ports = prompt[0].replace(/[\[\]]/g, "").split(/\|/);
         // only time prompt is used is when there are mutltiple ports
-        window
-          .showWarningMessage(
-            line,
-            ...ports
-          )
-          .then((response) => {
-            if (response) {
-              process.stdin?.write(response + "\n");
-            } else {
-              process.kill();
-            }
-          });
+        window.showWarningMessage(line, ...ports).then((response) => {
+          if (response) {
+            process.stdin?.write(response + "\n");
+          } else {
+            process.kill();
+          }
+        });
       }
 
       return false;

--- a/src/device.ts
+++ b/src/device.ts
@@ -108,7 +108,7 @@ export const getV5ComPorts = (): PROSDeviceInfo[] => {
 
 const getV5ComPortsInternal = async (): Promise<PROSDeviceInfo[]> => {
   const { stdout, stderr } = await promisify(child_process.exec)(
-    "pros lsusb --machine-output --no-analytics",
+    `pros lsusb --machine-output ${process.env["PROS_VSCODE_FLAGS"]}`,
     {
       timeout: 5000,
       env: {

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -218,6 +218,7 @@ export async function install(context: vscode.ExtensionContext) {
   let vexcomVersion = "1_0_0_23";
 
   if (cliVersion === undefined || toolchainVersion === undefined) {
+    preparingInstall.stop();
     throw new Error("Failed to access version number");
   }
 

--- a/src/views/tree-view.ts
+++ b/src/views/tree-view.ts
@@ -127,7 +127,11 @@ export class TreeButtonMultiSelect extends TreeItem {
         )
         .then((option) => {
           if (option !== undefined) {
-            vscode.commands.executeCommand(option.label);
+            options.forEach(([name, command])=> {
+              if (option.label === name) {
+                vscode.commands.executeCommand(command);
+              }
+            });
           }
         });
     });

--- a/src/views/tree-view.ts
+++ b/src/views/tree-view.ts
@@ -127,7 +127,7 @@ export class TreeButtonMultiSelect extends TreeItem {
         )
         .then((option) => {
           if (option !== undefined) {
-            options.forEach(([name, command])=> {
+            options.forEach(([name, command]) => {
               if (option.label === name) {
                 vscode.commands.executeCommand(command);
               }


### PR DESCRIPTION
Bugfixes before we release stuff
- change BaseCommand to add PROS_VSCODE_FLAGS only if the command being run is "pros" and the flags exist
- Remove PROS_VSCODE_FLAGS from args for clean
- Do `pros c ls-templates` instead of `pros c q` for getLatestKernelOkapiVersion
- Stop progress window for install when hitting GitHub rate limit
- Fix TreeButtonMultiSelect to run commands properly