### PR TITLE
:children_crossing: Don't prompt user to upgrade Okapi if Okapi isn't installed

### DIFF
--- a/src/commands/upgrade-project.ts
+++ b/src/commands/upgrade-project.ts
@@ -53,14 +53,14 @@ export const upgradeProject = async () => {
     const { target, curKernel, curOkapi } =
       await getCurrentKernelOkapiVersion();
     const { newKernel, newOkapi } = await getLatestKernelOkapiVersion(target);
-    if (curKernel === newKernel && curOkapi === newOkapi) {
+    if (curKernel === newKernel && (curOkapi === newOkapi || curOkapi === undefined)) {
       await vscode.window.showInformationMessage("Project is up to date!");
       return;
     }
 
     await userApproval(
       newKernel === curKernel ? undefined : newKernel,
-      newOkapi === curOkapi ? undefined : newOkapi
+      (newOkapi === curOkapi || curOkapi === undefined) ? undefined : newOkapi
     );
 
     await upgradeProjectCommand.runCommand();

--- a/src/commands/upgrade-project.ts
+++ b/src/commands/upgrade-project.ts
@@ -53,14 +53,17 @@ export const upgradeProject = async () => {
     const { target, curKernel, curOkapi } =
       await getCurrentKernelOkapiVersion();
     const { newKernel, newOkapi } = await getLatestKernelOkapiVersion(target);
-    if (curKernel === newKernel && (curOkapi === newOkapi || curOkapi === undefined)) {
+    if (
+      curKernel === newKernel &&
+      (curOkapi === newOkapi || curOkapi === undefined)
+    ) {
       await vscode.window.showInformationMessage("Project is up to date!");
       return;
     }
 
     await userApproval(
       newKernel === curKernel ? undefined : newKernel,
-      (newOkapi === curOkapi || curOkapi === undefined) ? undefined : newOkapi
+      newOkapi === curOkapi || curOkapi === undefined ? undefined : newOkapi
     );
 
     await upgradeProjectCommand.runCommand();


### PR DESCRIPTION
Our upgrade project message is pretty dumb and always assumes the user has both kernel and okapi installed. This PR does a quick and dirty check for if Okapi is currently installed in their project, and doesn't prompt the user to upgrade Okapi if it isn't installed.