### PR TITLE
:bug: Write "N" to stdin when declining y/N prompts from CLI

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -264,7 +264,7 @@ export class BaseCommand {
           if (response === "Yes") {
             process.stdin?.write("y\n");
           } else {
-            process.kill();
+            process.stdin?.write("N\n");
           }
         });
       } else if (line.startsWith("Multiple") && prompt) {


### PR DESCRIPTION
Previously we just killed the process, which causes problems with the new prompt to switch to pros 4 when creating a new project. Now we write "N" to stdin, to properly decline the y/N prompt.