### PR TITLE
🐛 Switch Brain View device info updating to event-based

### DIFF
--- a/media/brainView.js
+++ b/media/brainView.js
@@ -61,7 +61,7 @@
       programList.innerHTML = "Programs:<br>";
       deviceInfo.programs.forEach((program) => {
         //programList.innerHTML += `<option value=${program.slot} ${Number(program.slot) === Number(deviceInfo.currentSlot) ? "selected" : ""}>${program.file}</option>`;
-        programList.innerHTML += `Slot ${program.slot}: ${program.file}`;
+        programList.innerHTML += `Slot ${program.slot}: ${program.file}<br>`;
       });
       deviceContainer.innerHTML = "";
       deviceInfo.devices.forEach((device) => {
@@ -85,6 +85,4 @@
       }>${deviceInfo.desc}</option>`;
     });
   }
-
-  setInterval(vscode.postMessage, 3000, { type: "updateDeviceList" });
 })();

--- a/src/views/brain-view.ts
+++ b/src/views/brain-view.ts
@@ -8,6 +8,7 @@ import {
   setTeam,
 } from "../device";
 import { getNonce } from "./nonce";
+import { usb } from "usb";
 
 export class BrainViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = "pros.brainView";
@@ -40,6 +41,7 @@ export class BrainViewProvider implements vscode.WebviewViewProvider {
           break;
         case "setPort":
           setPort(data.port);
+          this.updatePortInfo();
           break;
         case "setName":
           setName(data.name);
@@ -48,6 +50,16 @@ export class BrainViewProvider implements vscode.WebviewViewProvider {
           setTeam(data.team);
           break;
       }
+    });
+    usb.addListener("attach", () => {
+      setTimeout(() => {
+        this.updateDeviceList();
+      }, 1000);
+    });
+    usb.addListener("detach", () => {
+      setTimeout(() => {
+        this.updateDeviceList();
+      }, 1000);
     });
     this.updateDeviceList();
   }


### PR DESCRIPTION
Previously, Brain View would update the device info every 3 seconds, which would sometimes interfere with the user running pros CLI commands. This PR uses the usb library to only update the device info when detecting a usb device has connected or disconnected.