### PR TITLE
:bug: Don't upload if build fails

### DIFF
--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -36,6 +36,7 @@ export type BaseCommandOptions = {
   extraOutput?: boolean;
   successMessage?: string;
   optionalArgs?: (string | undefined)[];
+  errorCallback?: (error: string) => void;
 };
 export class BaseCommand {
   command: string;
@@ -47,6 +48,7 @@ export class BaseCommand {
   exited: boolean = false;
   extraOutput?: string[];
   progressWindow: BackgroundProgress;
+  errorCallback?: (error: string) => void;
 
   constructor(options: BaseCommandOptions) {
     // the constructor is what is called whenever a new instance of the class is created
@@ -89,6 +91,7 @@ export class BaseCommand {
     this.requiresProsProject = options.requiresProsProject;
     this.extraOutput = options.extraOutput ? [] : undefined;
     this.successMessage = options.successMessage;
+    this.errorCallback = options.errorCallback;
 
     this.progressWindow = new BackgroundProgress(this.message, true, false);
     // As far as implementing this onto each command, there are two ways you can do this.
@@ -180,6 +183,9 @@ export class BaseCommand {
     child.stdout.on("data", (data) => {
       this.parseOutput(data.toString().split(/\r?\n/), child).catch((e) => {
         hasError = true;
+        if (this.errorCallback) {
+          this.errorCallback(e);
+        }
         vscode.window.showErrorMessage(e, "View Output").then((response) => {
           if (response) {
             output.show();
@@ -190,6 +196,9 @@ export class BaseCommand {
     child.stderr.on("data", (data) => {
       this.parseOutput(data.toString().split(/\r?\n/), child).catch((e) => {
         hasError = true;
+        if (this.errorCallback) {
+          this.errorCallback(e);
+        }
         vscode.window.showErrorMessage(e, "View Output").then((response) => {
           if (response) {
             output.show();

--- a/src/commands/buildUpload.ts
+++ b/src/commands/buildUpload.ts
@@ -3,19 +3,24 @@ import { window } from "vscode";
 import { upload } from "./upload";
 
 export const buildUpload = async () => {
+  var buildFailed = false;
   const buildCommandOptions: BaseCommandOptions = {
     command: "pros",
     args: ["make"],
     message: "Building Project",
     requiresProsProject: true,
     successMessage: "hidden",
+    errorCallback: () => {
+      buildFailed = true;
+    },
   };
   const buildCommand: BaseCommand = new BaseCommand(buildCommandOptions);
   try {
     await buildCommand.runCommand();
   } catch (err: any) {
     await window.showErrorMessage(err.message);
-    return;
   }
-  await upload();
+  if (!buildFailed) {
+    await upload();
+  }
 };

--- a/src/commands/buildUpload.ts
+++ b/src/commands/buildUpload.ts
@@ -15,6 +15,7 @@ export const buildUpload = async () => {
     await buildCommand.runCommand();
   } catch (err: any) {
     await window.showErrorMessage(err.message);
+    return;
   }
   await upload();
 };


### PR DESCRIPTION
In buildUpload, we catch the error in build, but continue to upload even if we fail. So this just adds a return in the catch block so we don't upload if the build fails.