### PR TITLE
:bug: Don't add compileCommands to c_cpp_properties

### DIFF
--- a/src/workspace_utils.ts
+++ b/src/workspace_utils.ts
@@ -292,12 +292,6 @@ const modifyCCppJson = async (
     json.configurations[0].includePath.push(include);
   }
 
-  // Secibdm setup compile_commands.json filepath
-  json.configurations[0].compileCommands = path.join(
-    dirpath.fsPath,
-    "compile_commands.json"
-  );
-
   // Third, setup cStandard, cppStandard, and intelliSenseMode
   json.configurations[0].cStandard = "gnu11";
   json.configurations[0].cppStandard = "gnu++20";


### PR DESCRIPTION
The VSCode C/C++ extension no longer likes the compile_commands we generate for clangd, probably because we aren't actually compiling for clang. We can either generate a separate compile_commands for the VSCode extension, or just remove the compileCommands option from the c_cpp_properties.json we generate. The second option is simpler, since the first would require changes in the CLI (to generate a separate compile_commands for VSCode) and Kernel (to update the gitignore) as well.