### PR TITLE
:sparkles: Add option to uninstall CLI only

### DIFF
--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -74,6 +74,7 @@ export async function uninstall(context: vscode.ExtensionContext) {
   const labelResponse = await vscode.window.showInformationMessage(
     title,
     "Uninstall Now!",
+    "Uninstall CLI Only",
     "No Thanks."
   );
   if (labelResponse === "Uninstall Now!") {
@@ -91,6 +92,21 @@ export async function uninstall(context: vscode.ExtensionContext) {
       }
     );
     vscode.window.showInformationMessage("PROS Uninstalled!");
+  } else if (labelResponse === "Uninstall CLI Only") {
+    const cliName = `pros-cli-${getOperatingSystem()}`;
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Uninstalling PROS CLI",
+        cancellable: false,
+      },
+      async () => {
+        await vscode.workspace.fs.delete(
+          vscode.Uri.joinPath(context.globalStorageUri, "install", cliName),
+          { recursive: true }
+        );
+      }
+    );
   }
 }
 


### PR DESCRIPTION
This option is for people who want to re-install the CLI using an alternate method but don't want to uninstall everything else.