### PR TITLE
Fix: Corrected `selectKernelVersion` function to properly handle optional args

### DIFF
--- a/src/commands/command_tools.ts
+++ b/src/commands/command_tools.ts
@@ -143,7 +143,7 @@ export const selectKernelVersion = async (target: string) => {
   const kernelVersionCommandOptions: BaseCommandOptions = {
     command: "pros",
     args: ["c", "ls-templates", "--target", target, "--machine-output"],
-    optionalArgs: [betaFeaturesEnabled ? "--beta" : undefined],
+    optionalArgs: betaFeaturesEnabled ? ["--beta"] : [], // Fix: wrap in an array
     message: "Fetching kernel versions",
     requiresProsProject: false,
     extraOutput: true,


### PR DESCRIPTION
This pull request fixes an issue in the `selectKernelVersion` function where the `optionalArgs` property was not being properly defined. The fix involves wrapping the `--beta` argument in an array to ensure that the `optionalArgs` property is correctly defined.

Changes:

Modified the `kernelVersionCommandOptions` object in the `selectKernelVersion` function to properly define the `optionalArgs` property as an array.

Why:

The previous implementation of the `selectKernelVersion` function was incorrect, which could lead to errors when running the command. This fix ensures that the function works correctly and provides the expected behavior.

Testing:

I have tested the corrected `selectKernelVersion` function and verified that it works as expected.

* [x] I have tested the changes and verified that they work as expected.
* [x] I have followed the coding style and conventions of the project.
* [x] I have included a clear and concise description of the changes.

Request:

Please review and merge this pull request to fix the `selectKernelVersion` function. 

Cheers! 🍻