### PR TITLE
:bug: Make Vision Utility work on MacOS

### DIFF
--- a/src/commands/runvision.ts
+++ b/src/commands/runvision.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { BaseCommand, BaseCommandOptions } from "./base-command";
 import * as path from "path";
 import { getOperatingSystem } from "../one-click/install";
+import { exec } from "child_process";
 
 //run vision command
 const visionCommandOptions: BaseCommandOptions = {
@@ -31,28 +32,30 @@ export const runVision = async (context: vscode.ExtensionContext) => {
       `Vision Utility.exe`
     );
   } else {
+    /*
     vscode.window.showInformationMessage(
       "Vision Utility is currently not supported on MacOS. We are currently working on fixing this."
     );
     return;
-    visionCommandOptions.command = "open";
-    visionCommandOptions.args = [
-      "-a",
+    */
+    visionCommandOptions.command = 
       `"${path.join(
         installPath,
         "install",
         `pros-vision-${os}`,
         "osx64",
-        `Vision Utility.app`
-      )}"`,
-    ];
+        `Vision Utility.app`,
+        "Contents",
+        "MacOS",
+        "nwjs"
+      )}"`;
   }
 
   console.log(visionCommandOptions.command);
 
   const visionCommand: BaseCommand = new BaseCommand(visionCommandOptions);
   try {
-    visionCommand.runCommand();
+    exec(visionCommandOptions.command);
   } catch (err: any) {
     await vscode.window.showErrorMessage(
       "There is an error running Vision Utlity, check if it is installed"

--- a/src/commands/runvision.ts
+++ b/src/commands/runvision.ts
@@ -1,22 +1,14 @@
 import * as vscode from "vscode";
-import { BaseCommand, BaseCommandOptions } from "./base-command";
 import * as path from "path";
 import { getOperatingSystem } from "../one-click/install";
 import { exec } from "child_process";
-
-//run vision command
-const visionCommandOptions: BaseCommandOptions = {
-  command: "",
-  args: [""],
-  message: "Running Vision Utility",
-  requiresProsProject: false,
-  successMessage: "Vision Utility Started",
-};
+import { BackgroundProgress } from "../logger";
 
 //check if vision is installed and run it
 export const runVision = async (context: vscode.ExtensionContext) => {
   const installPath = context.globalStorageUri.fsPath;
   const os = getOperatingSystem();
+  var visionUtilityPath = "";
 
   if (os === "linux") {
     vscode.window.showErrorMessage("Vision Utility is not supported on Linux");
@@ -24,21 +16,15 @@ export const runVision = async (context: vscode.ExtensionContext) => {
   }
 
   if (os === "windows") {
-    visionCommandOptions.command = path.join(
+    visionUtilityPath = `"${path.join(
       installPath,
       "install",
       `pros-vision-${os}`,
       "win32",
       `Vision Utility.exe`
-    );
+    )}"`;
   } else {
-    /*
-    vscode.window.showInformationMessage(
-      "Vision Utility is currently not supported on MacOS. We are currently working on fixing this."
-    );
-    return;
-    */
-    visionCommandOptions.command = 
+    visionUtilityPath = 
       `"${path.join(
         installPath,
         "install",
@@ -51,11 +37,11 @@ export const runVision = async (context: vscode.ExtensionContext) => {
       )}"`;
   }
 
-  console.log(visionCommandOptions.command);
-
-  const visionCommand: BaseCommand = new BaseCommand(visionCommandOptions);
+  console.log(visionUtilityPath);
   try {
-    exec(visionCommandOptions.command);
+    const progressWindow = new BackgroundProgress("Starting Vision Utility", false, true);
+    exec(visionUtilityPath);
+    progressWindow.stop();
   } catch (err: any) {
     await vscode.window.showErrorMessage(
       "There is an error running Vision Utlity, check if it is installed"

--- a/src/commands/runvision.ts
+++ b/src/commands/runvision.ts
@@ -24,22 +24,25 @@ export const runVision = async (context: vscode.ExtensionContext) => {
       `Vision Utility.exe`
     )}"`;
   } else {
-    visionUtilityPath = 
-      `"${path.join(
-        installPath,
-        "install",
-        `pros-vision-${os}`,
-        "osx64",
-        `Vision Utility.app`,
-        "Contents",
-        "MacOS",
-        "nwjs"
-      )}"`;
+    visionUtilityPath = `"${path.join(
+      installPath,
+      "install",
+      `pros-vision-${os}`,
+      "osx64",
+      `Vision Utility.app`,
+      "Contents",
+      "MacOS",
+      "nwjs"
+    )}"`;
   }
 
   console.log(visionUtilityPath);
   try {
-    const progressWindow = new BackgroundProgress("Starting Vision Utility", false, true);
+    const progressWindow = new BackgroundProgress(
+      "Starting Vision Utility",
+      false,
+      true
+    );
     exec(visionUtilityPath);
     progressWindow.stop();
   } catch (err: any) {

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -10,6 +10,7 @@ import * as path from "path";
 import { promisify } from "util";
 
 import { prosLogger } from "../extension";
+import { execSync } from "child_process";
 
 async function download(
   globalPath: string,
@@ -206,8 +207,12 @@ export async function extract(
         let writePath = path.join(globalPath, "install", storagePath);
 
         // Extract the contents of  the zip file
-        var zip = new admzip(readPath);
-        zip.extractAllTo(writePath, true);
+        if (readPath.includes("pros-vision-macos")) {
+          execSync(`unzip ${readPath.replace(" ", "\\ ")} -d ${writePath.replace(" ", "\\ ")}`);
+        } else {
+          var zip = new admzip(readPath);
+          zip.extractAllTo(writePath, true);
+        }
         await prosLogger.log(
           "OneClick",
           `Extracting ${readPath} to ${writePath}`

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -208,7 +208,12 @@ export async function extract(
 
         // Extract the contents of  the zip file
         if (readPath.includes("pros-vision-macos")) {
-          execSync(`unzip ${readPath.replace(" ", "\\ ")} -d ${writePath.replace(" ", "\\ ")}`);
+          execSync(
+            `unzip ${readPath.replace(" ", "\\ ")} -d ${writePath.replace(
+              " ",
+              "\\ "
+            )}`
+          );
         } else {
           var zip = new admzip(readPath);
           zip.extractAllTo(writePath, true);

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -804,10 +804,18 @@ export async function installVision(context: vscode.ExtensionContext) {
 
   // Set the installed file names
   const visionName = `pros-vision-${system}.zip`;
+
+  // delete existing vision utility installation, if it exists
+  try {
+    vscode.workspace.fs.delete(vscode.Uri.joinPath(context.globalStorageUri, "install", `pros-vision-${system}`), {recursive: true});
+  } catch (err: any) {
+    console.error(err);
+  }
+
   if (system === "windows") {
     console.log("vision utility on windows");
     //add install and download directories
-    const dirs = await createDirs(context.globalStorageUri);
+    await createDirs(context.globalStorageUri);
 
     const promises = [
       downloadextract(context, windowsVision, visionName, "Vision Utility"),
@@ -817,14 +825,8 @@ export async function installVision(context: vscode.ExtensionContext) {
     console.log("cleanup time");
     await cleanup(context, system);
   } else if (system === "macos") {
-    /*
-    vscode.window.showInformationMessage(
-      "Vision Utility is currently not supported on MacOS. We are currently working on fixing this."
-    );
-    return;
-    */
     //add install and download directories
-    const dirs = await createDirs(context.globalStorageUri);
+    await createDirs(context.globalStorageUri);
 
     const promises = [
       downloadextract(context, macosVision, visionName, "Vision Utility"),

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -800,10 +800,10 @@ export async function installVision(context: vscode.ExtensionContext) {
   const windowsVision =
     "https://github.com/purduesigbots/pros-cli/releases/download/3.4.1/vision_030_win32.zip";
   const macosVision =
-    "https://github.com/purduesigbots/pros-cli/releases/download/3.4.1/vision_030_osx64.zip";
+    "https://github.com/purduesigbots/pros-cli/releases/download/3.3.3/vision_030_osx64.zip";
 
   // Set the installed file names
-  var visionName = `pros-vision-${system}.zip`;
+  const visionName = `pros-vision-${system}.zip`;
   if (system === "windows") {
     console.log("vision utility on windows");
     //add install and download directories

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -807,7 +807,14 @@ export async function installVision(context: vscode.ExtensionContext) {
 
   // delete existing vision utility installation, if it exists
   try {
-    vscode.workspace.fs.delete(vscode.Uri.joinPath(context.globalStorageUri, "install", `pros-vision-${system}`), {recursive: true});
+    vscode.workspace.fs.delete(
+      vscode.Uri.joinPath(
+        context.globalStorageUri,
+        "install",
+        `pros-vision-${system}`
+      ),
+      { recursive: true }
+    );
   } catch (err: any) {
     console.error(err);
   }

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -817,10 +817,12 @@ export async function installVision(context: vscode.ExtensionContext) {
     console.log("cleanup time");
     await cleanup(context, system);
   } else if (system === "macos") {
+    /*
     vscode.window.showInformationMessage(
       "Vision Utility is currently not supported on MacOS. We are currently working on fixing this."
     );
     return;
+    */
     //add install and download directories
     const dirs = await createDirs(context.globalStorageUri);
 


### PR DESCRIPTION
Previously installing and running Vision Utility was unsupported on MacOS. This was due to adm-zip not properly creating the symbolic links in the MacOS app needed for it to run, corrupting the application. This PR fixes that by directly using the `unzip` executable that comes with MacOS to unzip the application and exec-ing the binary executable contained in the MacOS application directly, since spawning it from BaseCommand doesn't work properly.