### PR TITLE
feat: 🚸 Handle unsaved files on build

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,7 +1,70 @@
 import * as vscode from "vscode";
 import { BaseCommand, BaseCommandOptions } from "./base-command";
+import { output } from "../extension";
+
+/** Language IDs for C and C++ files */
+const C_CPP_LANG_IDS = ["cpp", "c"];
 
 export const build = async () => {
+  // TODO: Share this functionality with the build and upload command
+  // TODO: Suggest autosave somehow.
+  // TODO: If autosave is enabled, attempt to save all unsaved files in order to prevent edge cases with vscode's autosave.
+
+  /** Unsaved document uris likely belonging to the user's program's source code. */
+  const unsavedUris = vscode.workspace.textDocuments
+    .filter(
+      (doc) =>
+        doc.isDirty &&
+        C_CPP_LANG_IDS.includes(doc.languageId) &&
+        doc.uri.scheme !== "untitled"
+    )
+    .map((doc) => doc.uri);
+
+  // If there are unsaved files, prompt the user to save them
+  if (unsavedUris.length > 0) {
+    const multipleUnsaved = unsavedUris.length > 1;
+
+    // Change the message based on whether there are multiple unsaved files
+    let problem: string;
+    if (multipleUnsaved) {
+      problem = "Multiple files are not saved!";
+    } else {
+      const relativeFilePath = vscode.workspace.asRelativePath(unsavedUris[0]);
+      problem = `[${relativeFilePath}](${unsavedUris[0]}) is not saved!`;
+    }
+
+    // TODO: Add a link to some documentation?
+    const message = `${problem} This may cause problems with building. [Learn more](https://pros.cs.purdue.edu/)`;
+
+    // Show the message and get the user's response
+    const response = await vscode.window.showErrorMessage(
+      message,
+      multipleUnsaved ? "Save All" : "Save",
+      "Abort",
+      "Ignore",
+      "Don't Ask Again"
+    );
+
+    // Handle user response
+    switch (response) {
+      case "Save":
+      case "Save All":
+        await Promise.all(unsavedUris.map((uri) => vscode.workspace.save(uri)));
+        break;
+      case "Abort":
+        return;
+      // User pressed the 'x' button on the message
+      case undefined:
+      case "Ignore":
+        break;
+      case "Don't Ask Again":
+        output.appendLine(
+          "User chose to ignore unsaved files warning for PROS build."
+        );
+        // TODO: add setting to disable this warning
+        break;
+    }
+  }
   const buildCommandOptions: BaseCommandOptions = {
     command: "pros",
     args: ["make"],


### PR DESCRIPTION
Resolves #231 

- [ ] On build, if files are unsaved, prompt user action:
  - [x] Save unsaved files
  - [x] Ignore message
  - [x] Abort build
  - [ ] Don't show again
  - [ ] Enable autosave
- [ ] Handle edge cases of vscode's autosave, by automatically saving files before if autosave is enabled
- [ ] Improve UI
- [ ] Implement in build and upload command too