### PR TITLE
fix: :bug: Fix welcome webview checkboxes

### DIFF
--- a/media/welcome.js
+++ b/media/welcome.js
@@ -1,26 +1,45 @@
 // This script will be run within the webview itself
 // It cannot access the main VS Code APIs directly.
 
+// KNOWN EDGE CASE: The webview will not reflect changes to settings directly from the settings UI after it has been opened.
+//   This is rare and largely cosmetic, so it should be fine to leave.
 (function () {
   const vscode = acquireVsCodeApi();
 
   const useGoogleAnalytics = document.getElementById("useGoogleAnalytics");
   const showWelcomeOnStartup = document.getElementById("showWelcomeOnStartup");
 
+  // ensure that state is preserved when the webview is hidden and re-shown
+  const previousState = vscode.getState();
+  if (previousState) {
+    useGoogleAnalytics.checked = previousState?.useGoogleAnalytics;
+    showWelcomeOnStartup.checked = previousState?.showWelcomeOnStartup;
+  }
+
+  function saveState() {
+    vscode.setState({
+      useGoogleAnalytics: useGoogleAnalytics.checked,
+      showWelcomeOnStartup: showWelcomeOnStartup.checked,
+    });
+  }
+
   useGoogleAnalytics.addEventListener("change", (event) => {
     vscode.postMessage({
-      command: "useGoogleAnalytics",
+      command: "Enable Analytics",
       value: event.target.checked,
     });
+    saveState();
   });
 
   showWelcomeOnStartup.addEventListener("change", (event) => {
     vscode.postMessage({
-      command: "showWelcomeOnStartup",
+      command: "Show Welcome On Startup",
       value: event.target.checked,
     });
+    saveState();
   });
 
+  saveState();
   // Handle messages sent from the extension to the webview
   // window.addEventListener("message", (event) => {
   //   const message = event.data; // The json data that the extension sent

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -387,11 +387,11 @@ export async function activate(context: vscode.ExtensionContext) {
       const useGoogleAnalytics =
         vscode.workspace
           .getConfiguration("pros")
-          .get<boolean>("useGoogleAnalytics") ?? false;
+          .get<boolean>("Enable Analytics") ?? false;
       const showWelcomeOnStartup =
         vscode.workspace
           .getConfiguration("pros")
-          .get<boolean>("showWelcomeOnStartup") ?? false;
+          .get<boolean>("Show Welcome On Startup") ?? false;
 
       // Set the welcome page's html content
       panel.webview.html = getWebviewContent(


### PR DESCRIPTION
Resolves #235

Previously the welcome webview checkboxes wouldn't do anything. This fixes that.

#### Known edge case
The webview will not reflect changes to settings directly from the settings UI after it has been opened.
This is rare and largely cosmetic, so it should be fine to leave.