### PR TITLE
:bug: Make usb an optional dependency for Windows ARM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,7 @@
         "seek-bzip": "^2.0.0",
         "semver": "^7.5.2",
         "tar-fs": "^2.1.1",
-        "universal-analytics": "^0.5.3",
-        "usb": "^2.10.0"
+        "universal-analytics": "^0.5.3"
       },
       "devDependencies": {
         "@types/glob": "^7.1.3",
@@ -40,6 +39,9 @@
       },
       "engines": {
         "vscode": "^1.82.0"
+      },
+      "optionalDependencies": {
+        "usb": "^2.10.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -251,7 +253,8 @@
     "node_modules/@types/w3c-web-usb": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.10.tgz",
-      "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ=="
+      "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ==",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
@@ -2826,6 +2829,7 @@
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
       "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -3899,6 +3903,7 @@
       "resolved": "https://registry.npmjs.org/usb/-/usb-2.11.0.tgz",
       "integrity": "sha512-u5+NZ6DtoW8TIBtuSArQGAZZ/K15i3lYvZBAYmcgI+RcDS9G50/KPrUd3CrU8M92ahyCvg5e0gc8BDvr5Hwejg==",
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "@types/w3c-web-usb": "^1.0.6",
         "node-addon-api": "^7.0.0",
@@ -3912,6 +3917,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
       "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+      "optional": true,
       "engines": {
         "node": "^16 || ^18 || >= 20"
       }
@@ -4332,7 +4338,8 @@
     "@types/w3c-web-usb": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.10.tgz",
-      "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ=="
+      "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ==",
+      "optional": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
@@ -6207,7 +6214,8 @@
     "node-gyp-build": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og=="
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "optional": true
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -6983,6 +6991,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/usb/-/usb-2.11.0.tgz",
       "integrity": "sha512-u5+NZ6DtoW8TIBtuSArQGAZZ/K15i3lYvZBAYmcgI+RcDS9G50/KPrUd3CrU8M92ahyCvg5e0gc8BDvr5Hwejg==",
+      "optional": true,
       "requires": {
         "@types/w3c-web-usb": "^1.0.6",
         "node-addon-api": "^7.0.0",
@@ -6992,7 +7001,8 @@
         "node-addon-api": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
-          "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g=="
+          "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -447,7 +447,9 @@
     "seek-bzip": "^2.0.0",
     "semver": "^7.5.2",
     "tar-fs": "^2.1.1",
-    "universal-analytics": "^0.5.3",
+    "universal-analytics": "^0.5.3"
+  },
+  "optionalDependencies": {
     "usb": "^2.10.0"
   }
 }

--- a/src/device.ts
+++ b/src/device.ts
@@ -5,7 +5,11 @@ import { prosLogger } from "./extension";
 import { PREFIX } from "./commands/cli-parsing";
 import { StatusBarItem, window, workspace } from "vscode";
 import { BaseCommand } from "./commands";
-import { usb } from "usb";
+try {
+  var usb = require("usb").usb;
+} catch (err) {
+  usb = null;
+}
 
 /* eslint-disable @typescript-eslint/naming-convention */
 export type DeviceInfo = {
@@ -269,12 +273,14 @@ export const setTeam = async (team: string): Promise<void> => {
 };
 
 export const startPortMonitoring = (status: StatusBarItem): void => {
-  status.show();
-  usb.addListener("attach", () => {
+  if (usb) {
+    status.show();
+    usb.addListener("attach", () => {
+      resolvePort(status);
+    });
+    usb.addListener("detach", () => {
+      resolvePort(status);
+    });
     resolvePort(status);
-  });
-  usb.addListener("detach", () => {
-    resolvePort(status);
-  });
-  resolvePort(status);
+  }
 };

--- a/src/views/brain-view.ts
+++ b/src/views/brain-view.ts
@@ -8,7 +8,11 @@ import {
   setTeam,
 } from "../device";
 import { getNonce } from "./nonce";
-import { usb } from "usb";
+try {
+  var usb = require("usb").usb;
+} catch (err) {
+  usb = null;
+}
 
 export class BrainViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = "pros.brainView";
@@ -51,16 +55,18 @@ export class BrainViewProvider implements vscode.WebviewViewProvider {
           break;
       }
     });
-    usb.addListener("attach", () => {
-      setTimeout(() => {
-        this.updateDeviceList();
-      }, 1000);
-    });
-    usb.addListener("detach", () => {
-      setTimeout(() => {
-        this.updateDeviceList();
-      }, 1000);
-    });
+    if (usb) {
+      usb.addListener("attach", () => {
+        setTimeout(() => {
+          this.updateDeviceList();
+        }, 1000);
+      });
+      usb.addListener("detach", () => {
+        setTimeout(() => {
+          this.updateDeviceList();
+        }, 1000);
+      });
+    }
     this.updateDeviceList();
   }
 


### PR DESCRIPTION
Makes the node-usb package an optional dependency, since it cannot be installed on Windows ARM. This allows the extension to run on Windows ARM computers. Making node-usb an optional dependency should still install the package on other operating systems.

Reference: #230 