### PR TITLE
:bug: fix some bugs in weird edge cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "adm-zip": "^0.5.10",
         "axios": "^1.7.4",
         "dotenv": "^16.3.1",
-        "lzma-native": "^8.0.6",
         "node-fetch": "^2.6.7",
         "seek-bzip": "^2.0.0",
         "semver": "^7.5.2",
@@ -42,6 +41,7 @@
         "vscode": "^1.82.0"
       },
       "optionalDependencies": {
+        "lzma-native": "^8.0.6",
         "usb": "^2.10.0"
       }
     },
@@ -2454,6 +2454,7 @@
       "integrity": "sha512-09xfg67mkL2Lz20PrrDeNYZxzeW7ADtpYFbwSQh9U8+76RIzx5QsJBMy8qikv3hbUPfpy6hqwxt6FcGK81g9AA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "node-addon-api": "^3.1.0",
         "node-gyp-build": "^4.2.1",
@@ -2470,7 +2471,8 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/markdown-it": {
       "version": "12.3.2",
@@ -2854,6 +2856,7 @@
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
       "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -5956,6 +5959,7 @@
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-8.0.6.tgz",
       "integrity": "sha512-09xfg67mkL2Lz20PrrDeNYZxzeW7ADtpYFbwSQh9U8+76RIzx5QsJBMy8qikv3hbUPfpy6hqwxt6FcGK81g9AA==",
+      "optional": true,
       "requires": {
         "node-addon-api": "^3.1.0",
         "node-gyp-build": "^4.2.1",
@@ -5965,7 +5969,8 @@
         "node-addon-api": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+          "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+          "optional": true
         }
       }
     },
@@ -6255,7 +6260,8 @@
     "node-gyp-build": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og=="
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "optional": true
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -443,7 +443,6 @@
     "adm-zip": "^0.5.10",
     "axios": "^1.7.4",
     "dotenv": "^16.3.1",
-    "lzma-native": "^8.0.6",
     "node-fetch": "^2.6.7",
     "seek-bzip": "^2.0.0",
     "semver": "^7.5.2",
@@ -451,6 +450,7 @@
     "universal-analytics": "^0.5.3"
   },
   "optionalDependencies": {
+    "lzma-native": "^8.0.6",
     "usb": "^2.10.0"
   }
 }

--- a/src/one-click/download.ts
+++ b/src/one-click/download.ts
@@ -3,7 +3,11 @@ import { window, ProgressLocation } from "vscode";
 var fetch = require("node-fetch");
 var admzip = require("adm-zip");
 var tar = require("tar-fs");
-var lzma = require("lzma-native");
+try {
+  var lzma = require("lzma-native");
+} catch (err) {
+  lzma = null;
+}
 import * as fs from "fs";
 import * as stream from "stream";
 import * as path from "path";

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -331,7 +331,7 @@ export async function install(context: vscode.ExtensionContext) {
 
   // Does the user's CLI have an update or does the user need to install/update
   const cliUpToDate = cliWorking
-    ? semver.gte(currentCliVersion, cliVersion)
+    ? semver.gte(semver.coerce(currentCliVersion) ?? "0.0.0", cliVersion)
     : false;
   const toolchainUpToDate = toolchainWorking
     ? semver.gte(currentToolchainVersion, toolchainVersion, { loose: true })
@@ -651,7 +651,7 @@ export async function configurePaths(
       "pros"
     )
   );
-  process.env["PROS_VSCODE_FLAGS"] = semver.gte(version, "3.2.4")
+  process.env["PROS_VSCODE_FLAGS"] = semver.gte(semver.coerce(version) ?? "0.0.0", "3.2.4")
     ? "--no-sentry --no-analytics"
     : "";
   await prosLogger.log(

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -651,7 +651,10 @@ export async function configurePaths(
       "pros"
     )
   );
-  process.env["PROS_VSCODE_FLAGS"] = semver.gte(semver.coerce(version) ?? "0.0.0", "3.2.4")
+  process.env["PROS_VSCODE_FLAGS"] = semver.gte(
+    semver.coerce(version) ?? "0.0.0",
+    "3.2.4"
+  )
     ? "--no-sentry --no-analytics"
     : "";
   await prosLogger.log(


### PR DESCRIPTION
Before release, I found some bugs in weird edge cases:
1. lzma-native does not have a version build for Windows ARM, just like node-usb
2. Installing pros cli from pip causes semver to freak out because it reports version number as four numbers (ex. 3.5.4.0)

I am fixing these by:
1. Making lzma-native an optional dependency, just like I did for node-usb. This should be fine, since lzma-native is only used to extract the toolchain xz files on mac and linux, and the windows toolchain is a zip file.
2. Coercing the pros cli version number so semver is happy