### PR TITLE
:bug: Fix getting version of externally installed toolchain

### DIFF
--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -334,7 +334,7 @@ export async function install(context: vscode.ExtensionContext) {
     ? semver.gte(semver.coerce(currentCliVersion) ?? "0.0.0", cliVersion)
     : false;
   const toolchainUpToDate = toolchainWorking
-    ? semver.gte(currentToolchainVersion, toolchainVersion, { loose: true })
+    ? semver.gte(semver.coerce(currentToolchainVersion) ?? "0.0.0", toolchainVersion, { loose: true })
     : false;
   await prosLogger.log(
     "OneClick",
@@ -355,7 +355,7 @@ export async function install(context: vscode.ExtensionContext) {
     `${
       toolchainUpToDate
         ? "Toolchain is up to date"
-        : "To0lchain is not up to date"
+        : "Toolchain is not up to date"
     }`,
     toolchainUpToDate ? "INFO" : "WARNING"
   );
@@ -651,6 +651,14 @@ export async function configurePaths(
       "pros"
     )
   );
+  let [currentToolchainVersion, isToolchainOneClickInstall] =
+    await getToolchainVersion(
+      path.join(
+        `${addQuotes ? `"` : ""}${toolchainPath}${addQuotes ? `"` : ""}`,
+        "bin",
+        "arm-none-eabi-g++"
+      )
+    );
   process.env["PROS_VSCODE_FLAGS"] = semver.gte(
     semver.coerce(version) ?? "0.0.0",
     "3.2.4"
@@ -662,6 +670,12 @@ export async function configurePaths(
     `CLI is installed through ${
       isOneClickInstall ? "one-click" : "other means"
     } with version ${version}`
+  );
+  await prosLogger.log(
+    "OneClick",
+    `Toolchain is installed through ${
+      isToolchainOneClickInstall ? "one-click" : "other means"
+    } with version ${currentToolchainVersion}`
   );
   console.log(`${isOneClickInstall} | ${version}`);
 

--- a/src/one-click/install.ts
+++ b/src/one-click/install.ts
@@ -334,7 +334,11 @@ export async function install(context: vscode.ExtensionContext) {
     ? semver.gte(semver.coerce(currentCliVersion) ?? "0.0.0", cliVersion)
     : false;
   const toolchainUpToDate = toolchainWorking
-    ? semver.gte(semver.coerce(currentToolchainVersion) ?? "0.0.0", toolchainVersion, { loose: true })
+    ? semver.gte(
+        semver.coerce(currentToolchainVersion) ?? "0.0.0",
+        toolchainVersion,
+        { loose: true }
+      )
     : false;
   await prosLogger.log(
     "OneClick",

--- a/src/one-click/installed.ts
+++ b/src/one-click/installed.ts
@@ -89,7 +89,7 @@ export async function getToolchainVersion(
   } catch {
     try {
       const { stdout } = await promisify(child_process.exec)(
-        `arm-none-eabi-g++ --version`,
+        `arm-none-eabi-g++ -dumpversion`,
         {
           env: {
             ...process.env,


### PR DESCRIPTION
Some users had issues with the new version because they had installed the toolchain through other means. This was because there was a typo in the command to get the version of externally installed toolchains. This PR fixes that issue, and adds some additional logging for toolchain installation information for better debugging of these sorts of issues.